### PR TITLE
Option to Send deliverSmResp manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 #common
+test-output/
 target/
 out/
 classes/

--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/MessageReceiverListenerImpl.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/MessageReceiverListenerImpl.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.examples;
 
@@ -27,26 +23,26 @@ import org.jsmpp.util.InvalidDeliveryReceiptException;
 
 /**
  * @author uudashr
- *
+ * 
  */
 public class MessageReceiverListenerImpl implements MessageReceiverListener {
-    public void onAcceptDeliverSm(DeliverSm deliverSm)
+    @Override
+    public boolean onAcceptDeliverSm(DeliverSm deliverSm)
             throws ProcessRequestException {
-        
+
         if (MessageType.SMSC_DEL_RECEIPT.containedIn(deliverSm.getEsmClass())) {
             // this message is delivery receipt
             try {
                 DeliveryReceipt delReceipt = deliverSm.getShortMessageAsDeliveryReceipt();
-                
+
                 // lets cover the id to hex string format
                 long id = Long.parseLong(delReceipt.getId()) & 0xffffffff;
                 String messageId = Long.toString(id, 16).toUpperCase();
-                
+
                 /*
-                 * you can update the status of your submitted message on the
-                 * database based on messageId
+                 * you can update the status of your submitted message on the database based on messageId
                  */
-                
+
                 System.out.println("Receiving delivery receipt for message '" + messageId + " ' from " + deliverSm.getSourceAddr() + " to " + deliverSm.getDestAddress() + " : " + delReceipt);
             } catch (InvalidDeliveryReceiptException e) {
                 System.err.println("Failed getting delivery receipt");
@@ -54,18 +50,21 @@ public class MessageReceiverListenerImpl implements MessageReceiverListener {
             }
         } else {
             // this message is regular short message
-            
+
             /*
              * you can save the incoming message to database.
              */
-            
+
             System.out.println("Receiving message : " + new String(deliverSm.getShortMessage()));
         }
+        return true;
     }
-    
+
+    @Override
     public void onAcceptAlertNotification(AlertNotification alertNotification) {
     }
-    
+
+    @Override
     public DataSmResult onAcceptDataSm(DataSm dataSm, Session source)
             throws ProcessRequestException {
         return null;

--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/SMPPServerSimulator.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/SMPPServerSimulator.java
@@ -67,7 +67,7 @@ public class SMPPServerSimulator extends ServerResponseDeliveryAdapter implement
     private static final Integer DEFAULT_PORT = 8056;
     private static final Logger logger = LoggerFactory.getLogger(SMPPServerSimulator.class);
     private final ExecutorService execService = Executors.newFixedThreadPool(5);
-    private final ExecutorService execServiceDelReciept = Executors.newFixedThreadPool(100);
+    private final ExecutorService execServiceDelReceipt = Executors.newFixedThreadPool(100);
     private final MessageIDGenerator messageIDGenerator = new RandomMessageIDGenerator();
     private int port;
     
@@ -88,7 +88,7 @@ public class SMPPServerSimulator extends ServerResponseDeliveryAdapter implement
                 execService.execute(new WaitBindTask(serverSession));
             }
         } catch (IOException e) {
-            logger.error("IO error occured", e);
+            logger.error("IO error occurred", e);
         }
     }
     
@@ -103,7 +103,7 @@ public class SMPPServerSimulator extends ServerResponseDeliveryAdapter implement
         MessageId messageId = messageIDGenerator.newMessageId();
         logger.debug("Receiving submit_sm '{}', and return message id {}", new String(submitSm.getShortMessage()), messageId);
         if (SMSCDeliveryReceipt.SUCCESS.containedIn(submitSm.getRegisteredDelivery()) || SMSCDeliveryReceipt.SUCCESS_FAILURE.containedIn(submitSm.getRegisteredDelivery())) {
-            execServiceDelReciept.execute(new DeliveryReceiptTask(source, submitSm, messageId));
+            execServiceDelReceipt.execute(new DeliveryReceiptTask(source, submitSm, messageId));
         }
         return messageId;
     }
@@ -121,7 +121,7 @@ public class SMPPServerSimulator extends ServerResponseDeliveryAdapter implement
                 messageId);
         if (SMSCDeliveryReceipt.SUCCESS.containedIn(submitMulti.getRegisteredDelivery())
                 || SMSCDeliveryReceipt.SUCCESS_FAILURE.containedIn(submitMulti.getRegisteredDelivery())) {
-            execServiceDelReciept.execute(new DeliveryReceiptTask(source, submitMulti, messageId));
+            execServiceDelReceipt.execute(new DeliveryReceiptTask(source, submitMulti, messageId));
         }
 
         return new SubmitMultiResult(messageId.getValue(), new UnsuccessDelivery[0]);
@@ -255,7 +255,7 @@ public class SMPPServerSimulator extends ServerResponseDeliveryAdapter implement
                         new RegisteredDelivery(0), 
                         DataCodings.ZERO, 
                         delRec.toString().getBytes());
-                logger.debug("Sending delivery reciept for message id " + messageId + ":" + stringValue);
+                logger.debug("Sending delivery receipt for message id " + messageId + ":" + stringValue);
             } catch (Exception e) {
                 logger.error("Failed sending delivery_receipt for message id " + messageId + ":" + stringValue, e);
             }

--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/SimpleSubmitSimpleReceiveExample.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/SimpleSubmitSimpleReceiveExample.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.examples;
 
@@ -76,9 +72,9 @@ public class SimpleSubmitSimpleReceiveExample {
 
             String messageId = session.submitShortMessage("CMT", TypeOfNumber.INTERNATIONAL,
                     NumberingPlanIndicator.UNKNOWN, "1616", TypeOfNumber.INTERNATIONAL, NumberingPlanIndicator.UNKNOWN,
-                    "628176504657", new ESMClass(), (byte)0, (byte)1, timeFormatter.format(new Date()), null,
-                    registeredDelivery, (byte)0, new GeneralDataCoding(Alphabet.ALPHA_DEFAULT, MessageClass.CLASS1,
-                            false), (byte)0, message.getBytes());
+                    "628176504657", new ESMClass(), (byte) 0, (byte) 1, SimpleSubmitSimpleReceiveExample.timeFormatter.format(new Date()), null,
+                    registeredDelivery, (byte) 0, new GeneralDataCoding(Alphabet.ALPHA_DEFAULT, MessageClass.CLASS1,
+                            false), (byte) 0, message.getBytes());
 
             System.out.println("Message submitted, message_id is " + messageId);
 
@@ -109,7 +105,8 @@ public class SimpleSubmitSimpleReceiveExample {
         // Set listener to receive deliver_sm
         session.setMessageReceiverListener(new MessageReceiverListener() {
 
-            public void onAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
+            @Override
+            public boolean onAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
                 if (MessageType.SMSC_DEL_RECEIPT.containedIn(deliverSm.getEsmClass())) {
                     // delivery receipt
                     try {
@@ -125,12 +122,15 @@ public class SimpleSubmitSimpleReceiveExample {
                     // regular short message
                     System.out.println("Receiving message : " + new String(deliverSm.getShortMessage()));
                 }
+                return true;
             }
 
+            @Override
             public void onAcceptAlertNotification(AlertNotification alertNotification) {
                 System.out.println("onAcceptAlertNotification");
             }
 
+            @Override
             public DataSmResult onAcceptDataSm(DataSm dataSm, Session source) throws ProcessRequestException {
                 System.out.println("onAcceptDataSm");
                 return null;

--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/StressServer.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/StressServer.java
@@ -93,7 +93,7 @@ public class StressServer implements Runnable, ServerMessageReceiverListener {
                 waitBindExecService.execute(new WaitBindTask(serverSession));
             }
         } catch (IOException e) {
-            logger.error("IO error occured", e);
+            logger.error("IO error occurred", e);
         }
     }
     
@@ -199,7 +199,7 @@ public class StressServer implements Runnable, ServerMessageReceiverListener {
                         new RegisteredDelivery(0), 
                         DataCodings.ZERO, 
                         delRec.toString().getBytes());
-                logger.debug("Sending delivery reciept for message id " + messageId + ":" + stringValue);
+                logger.debug("Sending delivery receipt for message id " + messageId + ":" + stringValue);
             } catch (Exception e) {
                 logger.error("Failed sending delivery_receipt for message id " + messageId + ":" + stringValue, e);
             }

--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/SubmitMultipartMultilangualExample.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/SubmitMultipartMultilangualExample.java
@@ -134,7 +134,7 @@ public class SubmitMultipartMultilangualExample {
 			e.printStackTrace();
 		}
 
-		// configure variables acording to if message contains national
+		// configure variables according to if message contains national
 		// characters
 		Alphabet alphabet = null;
 		int maximumSingleMessageSize = 0;

--- a/jsmpp/src/main/java/org/jsmpp/SMPPConstant.java
+++ b/jsmpp/src/main/java/org/jsmpp/SMPPConstant.java
@@ -332,14 +332,14 @@ public interface SMPPConstant {
      */
     public static final byte NPI_UNKNOWN = 0x00;
     public static final byte NPI_ISDN = 0x01;
-    public static final byte NPI_DATA = 0x02;
-    public static final byte NPI_TELEX = 0x03;
-    public static final byte NPI_LAND_MOBILE = 0x04;
+    public static final byte NPI_DATA = 0x03;
+    public static final byte NPI_TELEX = 0x04;
+    public static final byte NPI_LAND_MOBILE = 0x06;
     public static final byte NPI_NATIONAL = 0x08;
     public static final byte NPI_PRIVATE = 0x09;
-    public static final byte NPI_ERMES = 0x10;
-    public static final byte NPI_INTERNET = 0x14;
-    public static final byte NPI_WAP = 0x18;
+    public static final byte NPI_ERMES = 0x0a;
+    public static final byte NPI_INTERNET = 0x0e;
+    public static final byte NPI_WAP = 0x12;
 
     public static final short TAG_SC_INTERFACE_VERSION = 0x0210;
     public static final short TAG_SAR_MSG_REF_NUM = 0X020C;

--- a/jsmpp/src/main/java/org/jsmpp/bean/BindResp.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/BindResp.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.bean;
 
@@ -27,15 +23,16 @@ import org.jsmpp.bean.OptionalParameter.Tag;
  */
 public class BindResp extends Command {
     private static final long serialVersionUID = 6719708830304733989L;
-    
+
     private String systemId;
     private OptionalParameter[] optionalParameters;
-    
+
     /**
      * Default constructor.
      */
     public BindResp() {
         super();
+        optionalParameters = new OptionalParameter[0];
     }
 
     /**
@@ -50,26 +47,27 @@ public class BindResp extends Command {
     /**
      * Set the system_id.
      * 
-     * @param systemId is the system_id.
+     * @param systemId
+     *            is the system_id.
      */
     public void setSystemId(String systemId) {
         this.systemId = systemId;
     }
-    
+
     public <U extends OptionalParameter> U getOptionalParameter(Class<U> tagClass)
     {
-    	return OptionalParameters.get(tagClass, optionalParameters);
+        return OptionalParameters.get(tagClass, optionalParameters);
     }
-    
+
     public OptionalParameter getOptionalParameter(Tag tagEnum)
     {
-    	return OptionalParameters.get(tagEnum.code(), optionalParameters);
+        return OptionalParameters.get(tagEnum.code(), optionalParameters);
     }
-    
+
     public OptionalParameter[] getOptionalParameters() {
         return optionalParameters;
     }
-    
+
     public void setOptionalParameters(OptionalParameter[] optionalParameters) {
         this.optionalParameters = optionalParameters;
     }
@@ -86,22 +84,27 @@ public class BindResp extends Command {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (!super.equals(obj))
+        }
+        if (!super.equals(obj)) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
-        final BindResp other = (BindResp)obj;
-        if (!Arrays.equals(optionalParameters, other.optionalParameters))
+        }
+        final BindResp other = (BindResp) obj;
+        if (!Arrays.equals(optionalParameters, other.optionalParameters)) {
             return false;
+        }
         if (systemId == null) {
-            if (other.systemId != null)
+            if (other.systemId != null) {
                 return false;
-        } else if (!systemId.equals(other.systemId))
+            }
+        } else if (!systemId.equals(other.systemId)) {
             return false;
+        }
         return true;
     }
-    
-    
+
 }

--- a/jsmpp/src/main/java/org/jsmpp/bean/DeliverSm.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DeliverSm.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.bean;
 
@@ -19,327 +15,365 @@ import org.jsmpp.util.InvalidDeliveryReceiptException;
 
 /**
  * @author uudashr
- *
+ * 
  */
 public class DeliverSm extends MessageRequest {
-    
-	public DeliverSm() {
-		super();
-	}
-	
-	/**
-     * Get the short message as {@link DeliveryReceipt}. This method will be
-     * valid if the parsed short message valid and Message Type (esm_class)
-     * contains SMSC Delivery Receipt.
+
+    public DeliverSm() {
+        super();
+    }
+
+    /**
+     * Get the short message as {@link DeliveryReceipt}. This method will be valid if the parsed short message valid and
+     * Message Type (esm_class) contains SMSC Delivery Receipt.
      * 
      * @return the {@link DeliveryReceipt}.
-     * @throws InvalidDeliveryReceiptException if there is an error found while parsing delivery receipt.
+     * @throws InvalidDeliveryReceiptException
+     *             if there is an error found while parsing delivery receipt.
      */
-	public DeliveryReceipt getShortMessageAsDeliveryReceipt()
+    public DeliveryReceipt getShortMessageAsDeliveryReceipt()
             throws InvalidDeliveryReceiptException {
-	    return getDeliveryReceipt(DefaultDeliveryReceiptStripper.getInstance());
-	}
-	
-	/**
-	 * Get delivery receipt based on specified strategy/stripper.
-	 * 
-	 * @param <T>
-	 * @param stripper is the stripper.
-	 * @return the delivery receipt as an instance of T.
-	 * @throws InvalidDeliveryReceiptException if there is an error found while parsing delivery receipt.
-	 */
-	public <T> T getDeliveryReceipt(DeliveryReceiptStrip<T> stripper)
+        return getDeliveryReceipt(DefaultDeliveryReceiptStripper.getInstance());
+    }
+
+    /**
+     * Create a response object for deliver_sm message synchronized with the sequence number.
+     * 
+     * @return DeliverSmResp to wrap deliver_sm_resp message.
+     */
+    public DeliverSmResp createResponse() {
+        DeliverSmResp resp = new DeliverSmResp();
+        resp.setSequenceNumber(getSequenceNumber());
+        return resp;
+    }
+
+    /**
+     * Get delivery receipt based on specified strategy/stripper.
+     * 
+     * @param <T>
+     * @param stripper
+     *            is the stripper.
+     * @return the delivery receipt as an instance of T.
+     * @throws InvalidDeliveryReceiptException
+     *             if there is an error found while parsing delivery receipt.
+     */
+    public <T> T getDeliveryReceipt(DeliveryReceiptStrip<T> stripper)
             throws InvalidDeliveryReceiptException {
-	    return stripper.strip(this);
-	}
-	
-	/**
-	 * Message Type.
-	 * @return
-	 */
-	public boolean isSmscDeliveryReceipt() {
-		return isSmscDeliveryReceipt(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param value
-	 */
-	public void setSmscDeliveryReceipt() {
-		esmClass = composeSmscDeliveryReceipt(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 * @return
-	 */
-	public boolean isSmeManualAcknowledgment() {
-		return isSmeManualAcknowledgment(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 */
-	public void setSmeManualAcknowledgment() {
-		esmClass = composeSmeManualAcknowledment(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 * @return
-	 */
-	public boolean isConversationAbort() {
-		return isConversationAbort(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 */
-	public void setConversationAbort() {
-		esmClass = composeConversationAbort(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 * @return
-	 */
-	public boolean isIntermedietDeliveryNotification() {
-		return isIntermedietDeliveryNotification(esmClass);
-	}
-	
-	/**
-	 * Message Type.
-	 */
-	public void setIntermedietDeliveryNotification() {
-		esmClass = composeIntermedietDeliveryNotification(esmClass);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @return
-	 */
-	public boolean isSmeAckNotRequested() {
-		return isSmeAckNotRequested(registeredDelivery);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 */
-	public void setSmeAckNotRequested() {
-		registeredDelivery = composeSmeAckNotRequested(registeredDelivery);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @return
-	 */
-	public boolean isSmeDeliveryAckRequested() {
-		return isSmeDeliveryAckRequested(registeredDelivery);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 */
-	public void setSmeDeliveryAckRequested() {
-		registeredDelivery = composeSmeDeliveryAckRequested(registeredDelivery);
-	}
-	
-	/**
-	 * SME originated Acknowledgement.
-	 * @return
-	 */
-	public boolean isSmeManualAckRequested() {
-		return isSmeManualAckRequested(registeredDelivery);
-	}
-	
-	/**
-	 * 
-	 * SME originated Acknowledgement.
-	 */
-	public void setSmeManualAckRequested() {
-		registeredDelivery = composeSmeManualAckRequested(registeredDelivery);
-	}
-	
-	/**
-	 * SME originated Acknowledgement.
-	 * @return
-	 */
-	public boolean isSmeDeliveryAndManualAckRequested() {
-		return isSmeDeliveryAndManualAckRequested(registeredDelivery);
-	}
-	
-	/**
-	 * SME originated Acknowledgement.
-	 */
-	public void setSmeDeliveryAndManualAckRequested() {
-		registeredDelivery = composeSmeDeliveryAndManualAckRequested(registeredDelivery);
-	}
-	
-	/**
-	 * Message Type.
-	 * Return esm_class of deliver_sm or data_sm indicate delivery receipt or not.
-	 * @param esmClass
-	 * @return <tt>true</tt> if esmClass indicate delivery receipt
-	 */
-	public static final boolean isSmscDeliveryReceipt(byte esmClass) {
-		return isMessageType(esmClass, SMPPConstant.ESMCLS_SMSC_DELIV_RECEIPT);
-	}
-	
-	/**
-	 * Message Type.
-	 * Set esm_class as delivery receipt
-	 * @param esmClass
-	 * @return
-	 */
-	public static final byte composeSmscDeliveryReceipt(byte esmClass) {
-		return composeMessageType(esmClass, SMPPConstant.ESMCLS_SMSC_DELIV_RECEIPT);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final boolean isSmeDeliveryAcknowledgment(byte esmClass) {
-		return isMessageType(esmClass, SMPPConstant.ESMCLS_SME_DELIV_ACK);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final byte composeSmeDeliveryAcknowledment(byte esmClass) {
-		return composeMessageType(esmClass, SMPPConstant.ESMCLS_SME_DELIV_ACK);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final boolean isSmeManualAcknowledgment(byte esmClass) {
-		return isMessageType(esmClass, SMPPConstant.ESMCLS_SME_MANUAL_ACK);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final byte composeSmeManualAcknowledment(byte esmClass) {
-		return composeMessageType(esmClass, SMPPConstant.ESMCLS_SME_MANUAL_ACK);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final boolean isConversationAbort(byte esmClass) {
-		return isMessageType(esmClass, SMPPConstant.ESMCLS_CONV_ABORT);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final byte composeConversationAbort(byte esmClass) {
-		return composeMessageType(esmClass, SMPPConstant.ESMCLS_CONV_ABORT);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final boolean isIntermedietDeliveryNotification(byte esmClass) {
-		return isMessageType(esmClass, SMPPConstant.ESMCLS_INTRMD_DELIV_NOTIF);
-	}
-	
-	/**
-	 * Message Type.
-	 * @param esmClass
-	 * @return
-	 */
-	public static final byte composeIntermedietDeliveryNotification(byte esmClass) {
-		return composeMessageType(esmClass, SMPPConstant.ESMCLS_INTRMD_DELIV_NOTIF);
-	}
-	
-	/*
-	 * SME originated Acknowledgement.
-	 */
-	
-	/**
-	 * SME originated Acknowledgement.
-	 * @param registeredDeliery
-	 * @return
-	 */
-	public static final boolean isSmeAckNotRequested(byte registeredDeliery) {
-		return isSmeAck(registeredDeliery, SMPPConstant.REGDEL_SME_ACK_NO);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDelivery
-	 * @return
-	 */
-	public static final byte composeSmeAckNotRequested(byte registeredDelivery) {
-		return composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_ACK_NO);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDeliery
-	 * @return
-	 */
-	public static final boolean isSmeDeliveryAckRequested(byte registeredDeliery) {
-		return isSmeAck(registeredDeliery, SMPPConstant.REGDEL_SME_DELIVERY_ACK_REQUESTED);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDelivery
-	 * @return
-	 */
-	public static final byte composeSmeDeliveryAckRequested(byte registeredDelivery) {
-		return composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_DELIVERY_ACK_REQUESTED);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDelivery
-	 * @return
-	 */
-	public static final boolean isSmeManualAckRequested(byte registeredDelivery) {
-		return isSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_MANUAL_ACK_REQUESTED);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDelivery
-	 * @return
-	 */
-	public static final byte composeSmeManualAckRequested(byte registeredDelivery) {
-		return composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_MANUAL_ACK_REQUESTED);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDelivery
-	 * @return
-	 */
-	public static final boolean isSmeDeliveryAndManualAckRequested(byte registeredDelivery) {
-		return isSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_DELIVERY_MANUAL_ACK_REQUESTED);
-	}
-	
-	/**
-	 * SME originated Acknowledgment.
-	 * @param registeredDelivery
-	 * @return
-	 */
-	public static final byte composeSmeDeliveryAndManualAckRequested(byte registeredDelivery) {
-		return composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_DELIVERY_MANUAL_ACK_REQUESTED);
-	}
+        return stripper.strip(this);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @return
+     */
+    public boolean isSmscDeliveryReceipt() {
+        return DeliverSm.isSmscDeliveryReceipt(esmClass);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param value
+     */
+    public void setSmscDeliveryReceipt() {
+        esmClass = DeliverSm.composeSmscDeliveryReceipt(esmClass);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @return
+     */
+    public boolean isSmeManualAcknowledgment() {
+        return DeliverSm.isSmeManualAcknowledgment(esmClass);
+    }
+
+    /**
+     * Message Type.
+     */
+    public void setSmeManualAcknowledgment() {
+        esmClass = DeliverSm.composeSmeManualAcknowledment(esmClass);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @return
+     */
+    public boolean isConversationAbort() {
+        return DeliverSm.isConversationAbort(esmClass);
+    }
+
+    /**
+     * Message Type.
+     */
+    public void setConversationAbort() {
+        esmClass = DeliverSm.composeConversationAbort(esmClass);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @return
+     */
+    public boolean isIntermedietDeliveryNotification() {
+        return DeliverSm.isIntermedietDeliveryNotification(esmClass);
+    }
+
+    /**
+     * Message Type.
+     */
+    public void setIntermedietDeliveryNotification() {
+        esmClass = DeliverSm.composeIntermedietDeliveryNotification(esmClass);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @return
+     */
+    public boolean isSmeAckNotRequested() {
+        return DeliverSm.isSmeAckNotRequested(registeredDelivery);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     */
+    public void setSmeAckNotRequested() {
+        registeredDelivery = DeliverSm.composeSmeAckNotRequested(registeredDelivery);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @return
+     */
+    public boolean isSmeDeliveryAckRequested() {
+        return DeliverSm.isSmeDeliveryAckRequested(registeredDelivery);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     */
+    public void setSmeDeliveryAckRequested() {
+        registeredDelivery = DeliverSm.composeSmeDeliveryAckRequested(registeredDelivery);
+    }
+
+    /**
+     * SME originated Acknowledgement.
+     * 
+     * @return
+     */
+    public boolean isSmeManualAckRequested() {
+        return DeliverSm.isSmeManualAckRequested(registeredDelivery);
+    }
+
+    /**
+     * 
+     * SME originated Acknowledgement.
+     */
+    public void setSmeManualAckRequested() {
+        registeredDelivery = DeliverSm.composeSmeManualAckRequested(registeredDelivery);
+    }
+
+    /**
+     * SME originated Acknowledgement.
+     * 
+     * @return
+     */
+    public boolean isSmeDeliveryAndManualAckRequested() {
+        return DeliverSm.isSmeDeliveryAndManualAckRequested(registeredDelivery);
+    }
+
+    /**
+     * SME originated Acknowledgement.
+     */
+    public void setSmeDeliveryAndManualAckRequested() {
+        registeredDelivery = DeliverSm.composeSmeDeliveryAndManualAckRequested(registeredDelivery);
+    }
+
+    /**
+     * Message Type. Return esm_class of deliver_sm or data_sm indicate delivery receipt or not.
+     * 
+     * @param esmClass
+     * @return <tt>true</tt> if esmClass indicate delivery receipt
+     */
+    public static final boolean isSmscDeliveryReceipt(byte esmClass) {
+        return AbstractSmCommand.isMessageType(esmClass, SMPPConstant.ESMCLS_SMSC_DELIV_RECEIPT);
+    }
+
+    /**
+     * Message Type. Set esm_class as delivery receipt
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final byte composeSmscDeliveryReceipt(byte esmClass) {
+        return AbstractSmCommand.composeMessageType(esmClass, SMPPConstant.ESMCLS_SMSC_DELIV_RECEIPT);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final boolean isSmeDeliveryAcknowledgment(byte esmClass) {
+        return AbstractSmCommand.isMessageType(esmClass, SMPPConstant.ESMCLS_SME_DELIV_ACK);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final byte composeSmeDeliveryAcknowledment(byte esmClass) {
+        return AbstractSmCommand.composeMessageType(esmClass, SMPPConstant.ESMCLS_SME_DELIV_ACK);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final boolean isSmeManualAcknowledgment(byte esmClass) {
+        return AbstractSmCommand.isMessageType(esmClass, SMPPConstant.ESMCLS_SME_MANUAL_ACK);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final byte composeSmeManualAcknowledment(byte esmClass) {
+        return AbstractSmCommand.composeMessageType(esmClass, SMPPConstant.ESMCLS_SME_MANUAL_ACK);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final boolean isConversationAbort(byte esmClass) {
+        return AbstractSmCommand.isMessageType(esmClass, SMPPConstant.ESMCLS_CONV_ABORT);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final byte composeConversationAbort(byte esmClass) {
+        return AbstractSmCommand.composeMessageType(esmClass, SMPPConstant.ESMCLS_CONV_ABORT);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final boolean isIntermedietDeliveryNotification(byte esmClass) {
+        return AbstractSmCommand.isMessageType(esmClass, SMPPConstant.ESMCLS_INTRMD_DELIV_NOTIF);
+    }
+
+    /**
+     * Message Type.
+     * 
+     * @param esmClass
+     * @return
+     */
+    public static final byte composeIntermedietDeliveryNotification(byte esmClass) {
+        return AbstractSmCommand.composeMessageType(esmClass, SMPPConstant.ESMCLS_INTRMD_DELIV_NOTIF);
+    }
+
+    /*
+     * SME originated Acknowledgement.
+     */
+
+    /**
+     * SME originated Acknowledgement.
+     * 
+     * @param registeredDeliery
+     * @return
+     */
+    public static final boolean isSmeAckNotRequested(byte registeredDeliery) {
+        return AbstractSmCommand.isSmeAck(registeredDeliery, SMPPConstant.REGDEL_SME_ACK_NO);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDelivery
+     * @return
+     */
+    public static final byte composeSmeAckNotRequested(byte registeredDelivery) {
+        return AbstractSmCommand.composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_ACK_NO);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDeliery
+     * @return
+     */
+    public static final boolean isSmeDeliveryAckRequested(byte registeredDeliery) {
+        return AbstractSmCommand.isSmeAck(registeredDeliery, SMPPConstant.REGDEL_SME_DELIVERY_ACK_REQUESTED);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDelivery
+     * @return
+     */
+    public static final byte composeSmeDeliveryAckRequested(byte registeredDelivery) {
+        return AbstractSmCommand.composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_DELIVERY_ACK_REQUESTED);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDelivery
+     * @return
+     */
+    public static final boolean isSmeManualAckRequested(byte registeredDelivery) {
+        return AbstractSmCommand.isSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_MANUAL_ACK_REQUESTED);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDelivery
+     * @return
+     */
+    public static final byte composeSmeManualAckRequested(byte registeredDelivery) {
+        return AbstractSmCommand.composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_MANUAL_ACK_REQUESTED);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDelivery
+     * @return
+     */
+    public static final boolean isSmeDeliveryAndManualAckRequested(byte registeredDelivery) {
+        return AbstractSmCommand.isSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_DELIVERY_MANUAL_ACK_REQUESTED);
+    }
+
+    /**
+     * SME originated Acknowledgment.
+     * 
+     * @param registeredDelivery
+     * @return
+     */
+    public static final byte composeSmeDeliveryAndManualAckRequested(byte registeredDelivery) {
+        return AbstractSmCommand.composeSmeAck(registeredDelivery, SMPPConstant.REGDEL_SME_DELIVERY_MANUAL_ACK_REQUESTED);
+    }
 }

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
@@ -49,7 +49,7 @@ public abstract class OptionalParameter {
         return buffer.array();
     }
 
-    /** This method should serialize the value part of the optional parameter. The format of the value is dependant
+    /** This method should serialize the value part of the optional parameter. The format of the value is dependent
      * on the specific optional parameter type so it is abstract and must be implmented by subclasses.
      * @return
      */

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameters.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameters.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.bean;
 
@@ -26,191 +22,197 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author uudashr
- *
+ * 
  */
 public class OptionalParameters {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(OptionalParameters.class);
+
     /**
      * Create SAR_MESSAGE_REF_NUM TLV instance.
      * 
-     * @param value is the value.
+     * @param value
+     *            is the value.
      * @return the optional parameter.
      */
     public static OptionalParameter.Short newSarMsgRefNum(short value) {
         return new OptionalParameter.Short(Tag.SAR_MSG_REF_NUM, value);
     }
-    
+
     /**
-     * Create SAR_MESSAGE_REF_NUM TLV instance.
-     * The value will cast automatically into short type.
+     * Create SAR_MESSAGE_REF_NUM TLV instance. The value will cast automatically into short type.
      * 
-     * @param value is the value.
+     * @param value
+     *            is the value.
      * @return the optional parameter.
      */
     public static OptionalParameter.Short newSarMsgRefNum(int value) {
-        return newSarMsgRefNum((byte)value);
+        return OptionalParameters.newSarMsgRefNum((byte) value);
     }
-    
+
     /**
      * Create SAR_SEGMENT_SEQNUM TLV instance.
      * 
-     * @param value is the value.
+     * @param value
+     *            is the value.
      * @return the optional parameter.
      */
     public static OptionalParameter.Byte newSarSegmentSeqnum(byte value) {
         return new OptionalParameter.Byte(Tag.SAR_SEGMENT_SEQNUM, value);
     }
-    
+
     /**
-     * Create SAR_SEGMENT_SEQNUM TLV instance.
-     * The value will cast automatically into byte type.
+     * Create SAR_SEGMENT_SEQNUM TLV instance. The value will cast automatically into byte type.
      * 
-     * @param value is the value.
+     * @param value
+     *            is the value.
      * @return the optional parameter.
      */
     public static OptionalParameter.Byte newSarSegmentSeqnum(int value) {
-        return newSarSegmentSeqnum((byte)value);
+        return OptionalParameters.newSarSegmentSeqnum((byte) value);
     }
-    
+
     /**
      * Create SAR_TOTAL_SEGMENTS TLV instance.
      * 
-     * @param value is the value.
+     * @param value
+     *            is the value.
      * @return the optional parameter.
      */
     public static OptionalParameter.Byte newSarTotalSegments(byte value) {
         return new OptionalParameter.Byte(Tag.SAR_TOTAL_SEGMENTS, value);
     }
-    
+
     /**
-     * Create SAR_TOTAL_SEGMENTS TLV instance.
-     * The value will cast automatically into byte type.
+     * Create SAR_TOTAL_SEGMENTS TLV instance. The value will cast automatically into byte type.
      * 
-     * @param value is the value.
+     * @param value
+     *            is the value.
      * @return the optional parameter.
      */
     public static OptionalParameter.Byte newSarTotalSegments(int value) {
-        return newSarTotalSegments((byte)value);
+        return OptionalParameters.newSarTotalSegments((byte) value);
     }
 
     /**
-     * Deserialize all recognized tag code to {@link OptionalParameter} object.
-     * Unrecognized will be classified as {@link COctetString}.
+     * Deserialize all recognized tag code to {@link OptionalParameter} object. Unrecognized will be classified as
+     * {@link COctetString}.
      * 
-     * @param tagCode is the tag code.
-     * @param content is the content.
+     * @param tagCode
+     *            is the tag code.
+     * @param content
+     *            is the content.
      * @return the OptionalParameter object.
      */
     public static OptionalParameter deserialize(short tagCode, byte[] content) {
         Tag tag = Tag.valueOf(tagCode);
-        if(tag == null) {
-            logger.warn("Optional Parameter Tag not recognized for deserialization: " + tagCode);
+        if (tag == null) {
+            OptionalParameters.logger.warn("Optional Parameter Tag not recognized for deserialization: " + tagCode);
             return new COctetString(tagCode, content);
         }
-        
-        switch(tag)
+
+        switch (tag)
         {
-            case DEST_ADDR_SUBUNIT:
-                return new OptionalParameter.Dest_addr_subunit(content);
-            case DEST_NETWORK_TYPE:
-                return new OptionalParameter.Dest_network_type(content);
-            case DEST_BEARER_TYPE:
-                return new OptionalParameter.Dest_bearer_type(content);
-            case DEST_TELEMATICS_ID:
-                return new OptionalParameter.Dest_telematics_id(content);
-            case SOURCE_ADDR_SUBUNIT:
-                return new OptionalParameter.Source_addr_subunit(content);
-            case SOURCE_NETWORK_TYPE:
-                return new OptionalParameter.Source_network_type(content);
-            case SOURCE_BEARER_TYPE:
-                return new OptionalParameter.Source_bearer_type(content);
-            case SOURCE_TELEMATICS_ID:
-                return new OptionalParameter.Source_telematics_id(content);
-            case QOS_TIME_TO_LIVE:
-                return new OptionalParameter.Qos_time_to_live(content);
-            case PAYLOAD_TYPE:
-                return new OptionalParameter.Payload_type(content);
-            case ADDITIONAL_STATUS_INFO_TEXT:
-            	return new OptionalParameter.Additional_status_info_text(content);
-            case RECEIPTED_MESSAGE_ID:
-                return new OptionalParameter.Receipted_message_id(content);
-            case MS_MSG_WAIT_FACILITIES:
-            	return new OptionalParameter.Ms_msg_wait_facilities(content);
-            case PRIVACY_INDICATOR:
-            	return new OptionalParameter.Privacy_indicator(content);
-            case SOURCE_SUBADDRESS:
-            	return new OptionalParameter.Source_subaddress(content);
-            case DEST_SUBADDRESS:
-            	return new OptionalParameter.Dest_subaddress(content);
-            case USER_MESSAGE_REFERENCE:
-            	return new OptionalParameter.User_message_reference(content);
-            case USER_RESPONSE_CODE:
-            	return new OptionalParameter.User_response_code(content);
-            case SOURCE_PORT:
-            	return new OptionalParameter.Source_port(content);
-            case DESTINATION_PORT:
-            	return new OptionalParameter.Destination_port(content);
-            case SAR_MSG_REF_NUM:
-            	return new OptionalParameter.Sar_msg_ref_num(content);
-            case LANGUAGE_INDICATOR:
-            	return new OptionalParameter.Language_indicator(content);
-            case SAR_TOTAL_SEGMENTS:
-            	return new OptionalParameter.Sar_total_segments(content);
-            case SAR_SEGMENT_SEQNUM:
-            	return new OptionalParameter.Sar_segment_seqnum(content);
-            case SC_INTERFACE_VERSION:
-                return new OptionalParameter.Sc_interface_version(content);
-            case CALLBACK_NUM_PRES_IND:
-            	return new OptionalParameter.Callback_num_pres_ind(content);
-            case CALLBACK_NUM_ATAG:
-            	return new OptionalParameter.Callback_num_atag(content);
-            case NUMBER_OF_MESSAGES:
-            	return new OptionalParameter.Number_of_messages(content);
-            case CALLBACK_NUM:
-            	return new OptionalParameter.Callback_num(content);
-            case DPF_RESULT:
-            	return new OptionalParameter.Dpf_result(content);
-            case SET_DPF:
-            	return new OptionalParameter.Set_dpf(content);
-            case MS_AVAILABILITY_STATUS:
-            	return new OptionalParameter.Ms_availability_status(content);
-            case NETWORK_ERROR_CODE:
-            	return new OptionalParameter.Network_error_code(content);
-            case MESSAGE_PAYLOAD:
-                return new OptionalParameter.Message_payload(content);
-            case DELIVERY_FAILURE_REASON:
-            	return new OptionalParameter.Delivery_failure_reason(content);
-            case MORE_MESSAGES_TO_SEND:
-            	return new OptionalParameter.More_messages_to_send(content);
-            case MESSAGE_STATE:
-                return new OptionalParameter.Message_state(content);
-            case USSD_SERVICE_OP:
-            	return new OptionalParameter.Ussd_service_op(content);
-            case BILLING_IDENTIFICATION:
-            	return new OptionalParameter.Billing_identification(content);
-            case DISPLAY_TIME:
-            	return new OptionalParameter.Display_time(content);
-            case SMS_SIGNAL:
-            	return new OptionalParameter.Sms_signal(content);
-            case MS_VALIDITY:
-            	return new OptionalParameter.Ms_validity(content);
-            case ALERT_ON_MESSAGE_DELIVERY:
-            	return new OptionalParameter.Alert_on_message_delivery(content);
-            case ITS_REPLY_TYPE:
-            	return new OptionalParameter.Its_reply_type(content);
-            case ITS_SESSION_INFO:
-            	return new OptionalParameter.Its_session_info(content);
-            case VENDOR_SPECIFIC_SOURCE_MSC_ADDR:
-                return new OptionalParameter.Vendor_specific_source_msc_addr(content);
-            case VENDOR_SPECIFIC_DEST_MSC_ADDR:
-                return new OptionalParameter.Vendor_specific_dest_msc_addr(content);
-            default:
-                logger.warn("Missing code in deserialize to handle Optional Parameter Tag: " + tag);
+        case DEST_ADDR_SUBUNIT:
+            return new OptionalParameter.Dest_addr_subunit(content);
+        case DEST_NETWORK_TYPE:
+            return new OptionalParameter.Dest_network_type(content);
+        case DEST_BEARER_TYPE:
+            return new OptionalParameter.Dest_bearer_type(content);
+        case DEST_TELEMATICS_ID:
+            return new OptionalParameter.Dest_telematics_id(content);
+        case SOURCE_ADDR_SUBUNIT:
+            return new OptionalParameter.Source_addr_subunit(content);
+        case SOURCE_NETWORK_TYPE:
+            return new OptionalParameter.Source_network_type(content);
+        case SOURCE_BEARER_TYPE:
+            return new OptionalParameter.Source_bearer_type(content);
+        case SOURCE_TELEMATICS_ID:
+            return new OptionalParameter.Source_telematics_id(content);
+        case QOS_TIME_TO_LIVE:
+            return new OptionalParameter.Qos_time_to_live(content);
+        case PAYLOAD_TYPE:
+            return new OptionalParameter.Payload_type(content);
+        case ADDITIONAL_STATUS_INFO_TEXT:
+            return new OptionalParameter.Additional_status_info_text(content);
+        case RECEIPTED_MESSAGE_ID:
+            return new OptionalParameter.Receipted_message_id(content);
+        case MS_MSG_WAIT_FACILITIES:
+            return new OptionalParameter.Ms_msg_wait_facilities(content);
+        case PRIVACY_INDICATOR:
+            return new OptionalParameter.Privacy_indicator(content);
+        case SOURCE_SUBADDRESS:
+            return new OptionalParameter.Source_subaddress(content);
+        case DEST_SUBADDRESS:
+            return new OptionalParameter.Dest_subaddress(content);
+        case USER_MESSAGE_REFERENCE:
+            return new OptionalParameter.User_message_reference(content);
+        case USER_RESPONSE_CODE:
+            return new OptionalParameter.User_response_code(content);
+        case SOURCE_PORT:
+            return new OptionalParameter.Source_port(content);
+        case DESTINATION_PORT:
+            return new OptionalParameter.Destination_port(content);
+        case SAR_MSG_REF_NUM:
+            return new OptionalParameter.Sar_msg_ref_num(content);
+        case LANGUAGE_INDICATOR:
+            return new OptionalParameter.Language_indicator(content);
+        case SAR_TOTAL_SEGMENTS:
+            return new OptionalParameter.Sar_total_segments(content);
+        case SAR_SEGMENT_SEQNUM:
+            return new OptionalParameter.Sar_segment_seqnum(content);
+        case SC_INTERFACE_VERSION:
+            return new OptionalParameter.Sc_interface_version(content);
+        case CALLBACK_NUM_PRES_IND:
+            return new OptionalParameter.Callback_num_pres_ind(content);
+        case CALLBACK_NUM_ATAG:
+            return new OptionalParameter.Callback_num_atag(content);
+        case NUMBER_OF_MESSAGES:
+            return new OptionalParameter.Number_of_messages(content);
+        case CALLBACK_NUM:
+            return new OptionalParameter.Callback_num(content);
+        case DPF_RESULT:
+            return new OptionalParameter.Dpf_result(content);
+        case SET_DPF:
+            return new OptionalParameter.Set_dpf(content);
+        case MS_AVAILABILITY_STATUS:
+            return new OptionalParameter.Ms_availability_status(content);
+        case NETWORK_ERROR_CODE:
+            return new OptionalParameter.Network_error_code(content);
+        case MESSAGE_PAYLOAD:
+            return new OptionalParameter.Message_payload(content);
+        case DELIVERY_FAILURE_REASON:
+            return new OptionalParameter.Delivery_failure_reason(content);
+        case MORE_MESSAGES_TO_SEND:
+            return new OptionalParameter.More_messages_to_send(content);
+        case MESSAGE_STATE:
+            return new OptionalParameter.Message_state(content);
+        case USSD_SERVICE_OP:
+            return new OptionalParameter.Ussd_service_op(content);
+        case BILLING_IDENTIFICATION:
+            return new OptionalParameter.Billing_identification(content);
+        case DISPLAY_TIME:
+            return new OptionalParameter.Display_time(content);
+        case SMS_SIGNAL:
+            return new OptionalParameter.Sms_signal(content);
+        case MS_VALIDITY:
+            return new OptionalParameter.Ms_validity(content);
+        case ALERT_ON_MESSAGE_DELIVERY:
+            return new OptionalParameter.Alert_on_message_delivery(content);
+        case ITS_REPLY_TYPE:
+            return new OptionalParameter.Its_reply_type(content);
+        case ITS_SESSION_INFO:
+            return new OptionalParameter.Its_session_info(content);
+        case VENDOR_SPECIFIC_SOURCE_MSC_ADDR:
+            return new OptionalParameter.Vendor_specific_source_msc_addr(content);
+        case VENDOR_SPECIFIC_DEST_MSC_ADDR:
+            return new OptionalParameter.Vendor_specific_dest_msc_addr(content);
+        default:
+            OptionalParameters.logger.warn("Missing code in deserialize to handle Optional Parameter Tag: " + tag);
         }
 
         // fallback
-        logger.warn("Falling back to basic OptionalParameter types for " + tag);
+        OptionalParameters.logger.warn("Falling back to basic OptionalParameter types for " + tag);
         if (Null.class.isAssignableFrom(tag.type)) {
             return new Null(tagCode);
         }
@@ -235,23 +237,27 @@ public class OptionalParameters {
     @SuppressWarnings("unchecked")
     public static <U extends OptionalParameter> U get(Class<U> tagClass, OptionalParameter[] parameters)
     {
-        for(OptionalParameter i: parameters) {
-            if(i.getClass() == tagClass) {
-                return (U)i;
+        if (parameters != null) {
+            for (OptionalParameter i : parameters) {
+                if (i.getClass() == tagClass) {
+                    return (U) i;
+                }
             }
         }
-        logger.info("optional tag " + tagClass + " not found");
+        OptionalParameters.logger.info("optional tag " + tagClass + " not found");
         return null;
     }
 
     public static OptionalParameter get(short tag, OptionalParameter[] parameters)
     {
-        for(OptionalParameter i: parameters) {
-            if(i.tag == tag) {
-                return i;
+        if (parameters != null) {
+            for (OptionalParameter i : parameters) {
+                if (i.tag == tag) {
+                    return i;
+                }
             }
         }
-        logger.info("optional tag " + tag + " not found");
+        OptionalParameters.logger.info("optional tag " + tag + " not found");
         return null;
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -133,11 +133,11 @@ public abstract class AbstractSession implements Session {
     }
     
     /**
-     * Set total thread can read PDU and process it parallely. It's defaulted to
+     * Set total thread can read PDU and process it in parallel. It's defaulted to
      * 3.
      * 
      * @param pduProcessorDegree is the total thread can handle read and process
-     *        PDU parallely.
+     *        PDU in parallel.
      * @throws IllegalStateException if the PDU Reader has been started.
      */
     public void setPduProcessorDegree(int pduProcessorDegree) throws IllegalStateException {
@@ -149,10 +149,10 @@ public abstract class AbstractSession implements Session {
     }
     
     /**
-     * Get the total of thread that can handle read and process PDU parallely.
+     * Get the total of thread that can handle read and process PDU in parallel.
      * 
-     * @return the total of thread that can handle read and process PDU
-     *         parallely.
+     * @return the total of thread that can handle read and process PDU in
+     *         parallel.
      */
     public int getPduProcessorDegree() {
         return pduProcessorDegree;

--- a/jsmpp/src/main/java/org/jsmpp/session/ClientSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/ClientSession.java
@@ -17,7 +17,7 @@ import org.jsmpp.PDUException;
 import org.jsmpp.bean.Address;
 import org.jsmpp.bean.BindType;
 import org.jsmpp.bean.DataCoding;
-import org.jsmpp.bean.DeliverSm;
+import org.jsmpp.bean.DeliverSmResp;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.OptionalParameter;
@@ -164,7 +164,7 @@ public interface ClientSession extends Session {
             ResponseTimeoutException, InvalidResponseException,
             NegativeResponseException, IOException;
 
-    void sendDeliverSmResp(DeliverSm deliverSm) throws PDUException, ResponseTimeoutException,
+    void sendDeliverSmResp(DeliverSmResp deliverSmRes) throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException;
 
     /**

--- a/jsmpp/src/main/java/org/jsmpp/session/ClientSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/ClientSession.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session;
 
@@ -21,6 +17,7 @@ import org.jsmpp.PDUException;
 import org.jsmpp.bean.Address;
 import org.jsmpp.bean.BindType;
 import org.jsmpp.bean.DataCoding;
+import org.jsmpp.bean.DeliverSm;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.NumberingPlanIndicator;
 import org.jsmpp.bean.OptionalParameter;
@@ -32,47 +29,67 @@ import org.jsmpp.extra.NegativeResponseException;
 import org.jsmpp.extra.ResponseTimeoutException;
 
 /**
- * This interface provides all operation that the client session can do. It
- * doesn't distinct the operation of specific session type (Transmitter,
- * Receiver) it's just like Transceiver. The distinction might should be
- * recognized in a different way, such as by user code when they do a binding or
- * by throwing exception when invoking illegal operation.
+ * This interface provides all operation that the client session can do. It doesn't distinct the operation of specific
+ * session type (Transmitter, Receiver) it's just like Transceiver. The distinction might should be recognized in a
+ * different way, such as by user code when they do a binding or by throwing exception when invoking illegal operation.
  * 
  * @author uudashr
  * 
  */
 public interface ClientSession extends Session {
-    
+
     /**
-     * Submit a short message to specified destination address. This method will
-     * blocks until response received or timeout reached. This method simplify
-     * operations of sending SUBMIT_SM command and receiving the SUBMIT_SM_RESP.
+     * Submit a short message to specified destination address. This method will blocks until response received or
+     * timeout reached. This method simplify operations of sending SUBMIT_SM command and receiving the SUBMIT_SM_RESP.
      * 
-     * @param serviceType is the service_type.
-     * @param sourceAddrTon is the source_addr_ton.
-     * @param sourceAddrNpi is the source_addr_npi.
-     * @param sourceAddr is the source_addr.
-     * @param destAddrTon is the dest_addr_ton.
-     * @param destAddrNpi is the dest_addr_npi.
-     * @param destinationAddr is the destination_addr.
-     * @param esmClass is the esm_class.
-     * @param protocolId is the protocol_id.
-     * @param priorityFlag is the priority_flag.
-     * @param scheduleDeliveryTime is the schedule_delivery_time.
-     * @param validityPeriod is the validity_period.
-     * @param registeredDelivery is the registered_delivery.
-     * @param replaceIfPresentFlag is the replace_if_present_flag.
-     * @param dataCoding is the data_coding.
-     * @param smDefaultMsgId is the sm_default_msg_id.
-     * @param shortMessage is the short_message.
-     * @param optionalParameters is the optional parameters.
-     * @return the message_id to identified the submitted short message for
-     *         later use (delivery receipt, QUERY_SM, CANCEL_SM, REPLACE_SM).
-     * @throws PDUException if there is invalid PDU parameter found..
-     * @throws ResponseTimeoutException if timeout has been reach.
-     * @throws InvalidResponseException if response is invalid.
-     * @throws NegativeResponseException if negative response received.
-     * @throws IOException if there is an I/O error found.
+     * @param serviceType
+     *            is the service_type.
+     * @param sourceAddrTon
+     *            is the source_addr_ton.
+     * @param sourceAddrNpi
+     *            is the source_addr_npi.
+     * @param sourceAddr
+     *            is the source_addr.
+     * @param destAddrTon
+     *            is the dest_addr_ton.
+     * @param destAddrNpi
+     *            is the dest_addr_npi.
+     * @param destinationAddr
+     *            is the destination_addr.
+     * @param esmClass
+     *            is the esm_class.
+     * @param protocolId
+     *            is the protocol_id.
+     * @param priorityFlag
+     *            is the priority_flag.
+     * @param scheduleDeliveryTime
+     *            is the schedule_delivery_time.
+     * @param validityPeriod
+     *            is the validity_period.
+     * @param registeredDelivery
+     *            is the registered_delivery.
+     * @param replaceIfPresentFlag
+     *            is the replace_if_present_flag.
+     * @param dataCoding
+     *            is the data_coding.
+     * @param smDefaultMsgId
+     *            is the sm_default_msg_id.
+     * @param shortMessage
+     *            is the short_message.
+     * @param optionalParameters
+     *            is the optional parameters.
+     * @return the message_id to identified the submitted short message for later use (delivery receipt, QUERY_SM,
+     *         CANCEL_SM, REPLACE_SM).
+     * @throws PDUException
+     *             if there is invalid PDU parameter found..
+     * @throws ResponseTimeoutException
+     *             if timeout has been reach.
+     * @throws InvalidResponseException
+     *             if response is invalid.
+     * @throws NegativeResponseException
+     *             if negative response received.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     String submitShortMessage(String serviceType, TypeOfNumber sourceAddrTon,
             NumberingPlanIndicator sourceAddrNpi, String sourceAddr,
@@ -87,34 +104,53 @@ public interface ClientSession extends Session {
             NegativeResponseException, IOException;
 
     /**
-     * Submit short message to multiple destination address. It's similar to
-     * submit short message, but it sending to multiple address. This method
-     * will blocks until response received or timeout reached. This method is
-     * simplify operations of sending SUBMIT_MULTI and receiving
-     * SUBMIT_MULTI_RESP.
+     * Submit short message to multiple destination address. It's similar to submit short message, but it sending to
+     * multiple address. This method will blocks until response received or timeout reached. This method is simplify
+     * operations of sending SUBMIT_MULTI and receiving SUBMIT_MULTI_RESP.
      * 
-     * @param serviceType is the service_type.
-     * @param sourceAddrTon is the source_addr_ton.
-     * @param sourceAddrNpi is the source_addr_npi.
-     * @param sourceAddr is the source_addr.
-     * @param destinationAddresses is the destination addresses.
-     * @param esmClass is the esm_class.
-     * @param protocolId is the protocol_id.
-     * @param priorityFlag is the priority_flag.
-     * @param scheduleDeliveryTime is the schedule_delivery_time.
-     * @param validityPeriod is the validity_period.
-     * @param registeredDelivery is the registered_delivery.
-     * @param replaceIfPresentFlag is the replace_if_present_flag.
-     * @param dataCoding is the data_coding.
-     * @param smDefaultMsgId is the sm_default_msg_id.
-     * @param shortMessage is the short_message.
-     * @param optionalParameters is the optional parameters.
+     * @param serviceType
+     *            is the service_type.
+     * @param sourceAddrTon
+     *            is the source_addr_ton.
+     * @param sourceAddrNpi
+     *            is the source_addr_npi.
+     * @param sourceAddr
+     *            is the source_addr.
+     * @param destinationAddresses
+     *            is the destination addresses.
+     * @param esmClass
+     *            is the esm_class.
+     * @param protocolId
+     *            is the protocol_id.
+     * @param priorityFlag
+     *            is the priority_flag.
+     * @param scheduleDeliveryTime
+     *            is the schedule_delivery_time.
+     * @param validityPeriod
+     *            is the validity_period.
+     * @param registeredDelivery
+     *            is the registered_delivery.
+     * @param replaceIfPresentFlag
+     *            is the replace_if_present_flag.
+     * @param dataCoding
+     *            is the data_coding.
+     * @param smDefaultMsgId
+     *            is the sm_default_msg_id.
+     * @param shortMessage
+     *            is the short_message.
+     * @param optionalParameters
+     *            is the optional parameters.
      * @return the message_id and the un-success deliveries.
-     * @throws PDUException if there is invalid PDU parameter found.
-     * @throws ResponseTimeoutException if timeout has been reach.
-     * @throws InvalidResponseException if response is invalid.
-     * @throws NegativeResponseException if negative response received.
-     * @throws IOException if there is an I/O error found.
+     * @throws PDUException
+     *             if there is invalid PDU parameter found.
+     * @throws ResponseTimeoutException
+     *             if timeout has been reach.
+     * @throws InvalidResponseException
+     *             if response is invalid.
+     * @throws NegativeResponseException
+     *             if negative response received.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     SubmitMultiResult submitMultiple(String serviceType,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
@@ -127,23 +163,34 @@ public interface ClientSession extends Session {
             OptionalParameter... optionalParameters) throws PDUException,
             ResponseTimeoutException, InvalidResponseException,
             NegativeResponseException, IOException;
-    
+
+    void sendDeliverSmResp(DeliverSm deliverSm) throws PDUException, ResponseTimeoutException,
+            InvalidResponseException, NegativeResponseException, IOException;
+
     /**
-     * Query previous submitted short message based on it's message_id and
-     * message_id. This method will blocks until response received or timeout
-     * reached. This method is simplify operations of sending QUERY_SM and
-     * receiving QUERY_SM_RESP.
+     * Query previous submitted short message based on it's message_id and message_id. This method will blocks until
+     * response received or timeout reached. This method is simplify operations of sending QUERY_SM and receiving
+     * QUERY_SM_RESP.
      * 
-     * @param messageId is the message_id.
-     * @param sourceAddrTon is the source_addr_ton.
-     * @param sourceAddrNpi is the source_addr_npi.
-     * @param sourceAddr is the source_addr.
+     * @param messageId
+     *            is the message_id.
+     * @param sourceAddrTon
+     *            is the source_addr_ton.
+     * @param sourceAddrNpi
+     *            is the source_addr_npi.
+     * @param sourceAddr
+     *            is the source_addr.
      * @return the result of query short message.
-     * @throws PDUException if there is invalid PDU parameter found.
-     * @throws ResponseTimeoutException if timeout has been reach.
-     * @throws InvalidResponseException if response is invalid.
-     * @throws NegativeResponseException if negative response received.
-     * @throws IOException if there is an I/O error found.
+     * @throws PDUException
+     *             if there is invalid PDU parameter found.
+     * @throws ResponseTimeoutException
+     *             if timeout has been reach.
+     * @throws InvalidResponseException
+     *             if response is invalid.
+     * @throws NegativeResponseException
+     *             if negative response received.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     QuerySmResult queryShortMessage(String messageId,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
@@ -151,23 +198,35 @@ public interface ClientSession extends Session {
             InvalidResponseException, NegativeResponseException, IOException;
 
     /**
-     * Cancel the previous submitted short message. This method will blocks
-     * until response received or timeout reached. This method is simplify
-     * operations of sending CANCEL_SM and receiving CANCEL_SM_RESP.
+     * Cancel the previous submitted short message. This method will blocks until response received or timeout reached.
+     * This method is simplify operations of sending CANCEL_SM and receiving CANCEL_SM_RESP.
      * 
-     * @param serviceType is the service_type.
-     * @param messageId is the message_id.
-     * @param sourceAddrTon is the source_addr_ton.
-     * @param sourceAddrNpi is the source_addr_npi.
-     * @param sourceAddr is the source_addr.
-     * @param destAddrTon is the dest_addr_ton.
-     * @param destAddrNpi is the dest_addr_npi.
-     * @param destinationAddress is destination_address.
-     * @throws PDUException if there is invalid PDU parameter found.
-     * @throws ResponseTimeoutException if timeout has been reach.
-     * @throws InvalidResponseException if response is invalid.
-     * @throws NegativeResponseException if negative response received.
-     * @throws IOException if there is an I/O error found.
+     * @param serviceType
+     *            is the service_type.
+     * @param messageId
+     *            is the message_id.
+     * @param sourceAddrTon
+     *            is the source_addr_ton.
+     * @param sourceAddrNpi
+     *            is the source_addr_npi.
+     * @param sourceAddr
+     *            is the source_addr.
+     * @param destAddrTon
+     *            is the dest_addr_ton.
+     * @param destAddrNpi
+     *            is the dest_addr_npi.
+     * @param destinationAddress
+     *            is destination_address.
+     * @throws PDUException
+     *             if there is invalid PDU parameter found.
+     * @throws ResponseTimeoutException
+     *             if timeout has been reach.
+     * @throws InvalidResponseException
+     *             if response is invalid.
+     * @throws NegativeResponseException
+     *             if negative response received.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     void cancelShortMessage(String serviceType, String messageId,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
@@ -177,24 +236,37 @@ public interface ClientSession extends Session {
             InvalidResponseException, NegativeResponseException, IOException;
 
     /**
-     * Replace the previous submitted short message. This method will blocks
-     * until response received or timeout reached. This method is simplify
-     * operations of sending REPLACE_SM and receiving REPLACE_SM_RESP.
+     * Replace the previous submitted short message. This method will blocks until response received or timeout reached.
+     * This method is simplify operations of sending REPLACE_SM and receiving REPLACE_SM_RESP.
      * 
-     * @param messageId is the message_id.
-     * @param sourceAddrTon is the source_addr_ton.
-     * @param sourceAddrNpi is the source_addr_npi.
-     * @param sourceAddr is the source_addr.
-     * @param scheduleDeliveryTime is the schedule_delivery_time.
-     * @param validityPeriod is the validity_period.
-     * @param registeredDelivery is the registered_delivery.
-     * @param smDefaultMsgId is the sm_default_msg_id.
-     * @param shortMessage is the short_message.
-     * @throws PDUException if there is invalid PDU parameter found.
-     * @throws ResponseTimeoutException if timeout has been reach.
-     * @throws InvalidResponseException if response is invalid.
-     * @throws NegativeResponseException if negative response received.
-     * @throws IOException if there is an I/O error found.
+     * @param messageId
+     *            is the message_id.
+     * @param sourceAddrTon
+     *            is the source_addr_ton.
+     * @param sourceAddrNpi
+     *            is the source_addr_npi.
+     * @param sourceAddr
+     *            is the source_addr.
+     * @param scheduleDeliveryTime
+     *            is the schedule_delivery_time.
+     * @param validityPeriod
+     *            is the validity_period.
+     * @param registeredDelivery
+     *            is the registered_delivery.
+     * @param smDefaultMsgId
+     *            is the sm_default_msg_id.
+     * @param shortMessage
+     *            is the short_message.
+     * @throws PDUException
+     *             if there is invalid PDU parameter found.
+     * @throws ResponseTimeoutException
+     *             if timeout has been reach.
+     * @throws InvalidResponseException
+     *             if response is invalid.
+     * @throws NegativeResponseException
+     *             if negative response received.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     void replaceShortMessage(String messageId, TypeOfNumber sourceAddrTon,
             NumberingPlanIndicator sourceAddrNpi, String sourceAddr,
@@ -202,84 +274,115 @@ public interface ClientSession extends Session {
             RegisteredDelivery registeredDelivery, byte smDefaultMsgId,
             byte[] shortMessage) throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException;
-    
+
     /**
-     * Open connection and bind immediately. The default
-     * timeout is 1 minutes.
+     * Open connection and bind immediately. The default timeout is 1 minutes.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindType is the bind type.
-     * @param systemId is the system id.
-     * @param password is the password.
-     * @param systemType is the system type.
-     * @param addrTon is the address TON.
-     * @param addrNpi is the address NPI.
-     * @param addressRange is the address range.
-     * @throws IOException if there is an IO error found.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindType
+     *            is the bind type.
+     * @param systemId
+     *            is the system id.
+     * @param password
+     *            is the password.
+     * @param systemType
+     *            is the system type.
+     * @param addrTon
+     *            is the address TON.
+     * @param addrNpi
+     *            is the address NPI.
+     * @param addressRange
+     *            is the address range.
+     * @throws IOException
+     *             if there is an IO error found.
      */
     void connectAndBind(String host, int port, BindType bindType,
             String systemId, String password, String systemType,
             TypeOfNumber addrTon, NumberingPlanIndicator addrNpi,
             String addressRange) throws IOException;
-    
+
     /**
-     * Open connection and bind immediately with specified timeout. The default
-     * timeout is 1 minutes.
+     * Open connection and bind immediately with specified timeout. The default timeout is 1 minutes.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindType is the bind type.
-     * @param systemId is the system id.
-     * @param password is the password.
-     * @param systemType is the system type.
-     * @param addrTon is the address TON.
-     * @param addrNpi is the address NPI.
-     * @param addressRange is the address range.
-     * @param timeout is the timeout.
-     * @throws IOException if there is an IO error found.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindType
+     *            is the bind type.
+     * @param systemId
+     *            is the system id.
+     * @param password
+     *            is the password.
+     * @param systemType
+     *            is the system type.
+     * @param addrTon
+     *            is the address TON.
+     * @param addrNpi
+     *            is the address NPI.
+     * @param addressRange
+     *            is the address range.
+     * @param timeout
+     *            is the timeout.
+     * @throws IOException
+     *             if there is an IO error found.
      */
     public void connectAndBind(String host, int port, BindType bindType,
             String systemId, String password, String systemType,
             TypeOfNumber addrTon, NumberingPlanIndicator addrNpi,
             String addressRange, long timeout) throws IOException;
-    
+
     /**
      * Open connection and bind immediately.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindParam is the bind parameters.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindParam
+     *            is the bind parameters.
      * @return the SMSC system id.
-     * @throws IOException if there is an IO error found.
+     * @throws IOException
+     *             if there is an IO error found.
      */
     public String connectAndBind(String host, int port,
-            BindParameter bindParam) 
+            BindParameter bindParam)
             throws IOException;
-    
+
     /**
      * Open connection and bind immediately.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindParam is the bind parameters.
-     * @param timeout is the timeout.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindParam
+     *            is the bind parameters.
+     * @param timeout
+     *            is the timeout.
      * @return the SMSC system id.
-     * @throws IOException if there is an IO error found.
+     * @throws IOException
+     *             if there is an IO error found.
      */
     public String connectAndBind(String host, int port,
-            BindParameter bindParam, long timeout) 
+            BindParameter bindParam, long timeout)
             throws IOException;
-    
+
     /**
      * Get the current message receiver listener that is currently registered for this smpp session.
+     * 
      * @return The current message receiver listener
      */
     public MessageReceiverListener getMessageReceiverListener();
-    
+
     /**
      * Sets a message receiver listener for this smpp session.
-     * @param messageReceiverListener is the new listener
+     * 
+     * @param messageReceiverListener
+     *            is the new listener
      */
     public void setMessageReceiverListener(
             MessageReceiverListener messageReceiverListener);

--- a/jsmpp/src/main/java/org/jsmpp/session/MessageReceiverListener.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/MessageReceiverListener.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session;
 
@@ -19,13 +15,11 @@ import org.jsmpp.bean.DeliverSm;
 import org.jsmpp.extra.ProcessRequestException;
 
 /**
- * This listener will listen to every incoming short message, recognized by
- * deliver_sm command. The logic on this listener should be accomplish in a
- * short time, because the deliver_sm_resp will be processed after the logic
- * executed. Normal logic will be return the deliver_sm_resp with zero valued
- * command_status, or throw {@link ProcessRequestException} that gave non-zero
- * valued command_status (in means negative response) depends on the given error
- * code specified on the {@link ProcessRequestException}.
+ * This listener will listen to every incoming short message, recognized by deliver_sm command. The logic on this
+ * listener should be accomplish in a short time, because the deliver_sm_resp will be processed after the logic
+ * executed. Normal logic will be return the deliver_sm_resp with zero valued command_status, or throw
+ * {@link ProcessRequestException} that gave non-zero valued command_status (in means negative response) depends on the
+ * given error code specified on the {@link ProcessRequestException}.
  * 
  * @author uudashr
  * @version 1.0
@@ -37,17 +31,20 @@ public interface MessageReceiverListener extends GenericMessageReceiverListener 
     /**
      * This event raised when a short message received.
      * 
-     * @param deliverSm is the short message.
-     * @throws ProcessRequestException throw if there should be return Non-OK
-     *         command_status for the response.
+     * @param deliverSm
+     *            is the short message.
+     * @return <code>TRUE</code> if the message deliver_sm_resp should be processed after the logic of this method,
+     *         <code>FALSE</code> if the user sends manually the message deliver_sm_resp
+     * @throws ProcessRequestException
+     *             throw if there should be return Non-OK command_status for the response.
      */
-    void onAcceptDeliverSm(DeliverSm deliverSm)
-            throws ProcessRequestException;
-    
+    boolean onAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException;
+
     /**
      * This event raised when alert notification received.
      * 
-     * @param alertNotification is the alert notification.
+     * @param alertNotification
+     *            is the alert notification.
      */
     void onAcceptAlertNotification(AlertNotification alertNotification);
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/ResponseHandler.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/ResponseHandler.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session;
 
@@ -21,8 +17,7 @@ import org.jsmpp.bean.DeliverSm;
 import org.jsmpp.extra.ProcessRequestException;
 
 /**
- * <tt>ResponseHandler</tt> provide interface to handle response of the session
- * routines.
+ * <tt>ResponseHandler</tt> provide interface to handle response of the session routines.
  * 
  * @author uudashr
  * @version 1.0
@@ -35,18 +30,21 @@ public interface ResponseHandler extends BaseResponseHandler {
      * Process the deliver
      * 
      * @param deliverSm
+     * @return <code>TRUE</code> if the message deliver_sm_resp should be processed after the logic of this method,
+     *         <code>FALSE</code> if the user sends manually the message deliver_sm_resp
      * @throws ProcessRequestException
      */
-    void processDeliverSm(DeliverSm deliverSm)
-            throws ProcessRequestException;
+    boolean processDeliverSm(DeliverSm deliverSm) throws ProcessRequestException;
 
     /**
      * Response by sending <b>DELIVER_SM_RESP</b> to SMSC.
      * 
-     * @param sequenceNumber is the sequence number of original <b>DELIVER_SM</b> request.
-     * @throws IOException if an IO error occur.
+     * @param sequenceNumber
+     *            is the sequence number of original <b>DELIVER_SM</b> request.
+     * @throws IOException
+     *             if an IO error occur.
      */
     void sendDeliverSmResp(int commandStatus, int sequenceNumber) throws IOException;
-    
+
     void processAlertNotification(AlertNotification alertNotification);
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPClientOperation.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPClientOperation.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session;
 
@@ -18,7 +14,6 @@ import java.io.IOException;
 
 import org.jsmpp.InvalidResponseException;
 import org.jsmpp.PDUException;
-import org.jsmpp.PDUStringException;
 import org.jsmpp.bean.Address;
 import org.jsmpp.bean.BindType;
 import org.jsmpp.bean.DataCoding;

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session;
 
@@ -65,10 +61,9 @@ import org.jsmpp.util.DefaultComposer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
- * This is an object that used to communicate with SMPP Server or SMSC. It hide
- * all un-needed SMPP operation that might harm if the user code use it such as :
+ * This is an object that used to communicate with SMPP Server or SMSC. It hide all un-needed SMPP operation that might
+ * harm if the user code use it such as :
  * <ul>
  * <li>DELIVER_SM_RESP, should be called only as response to DELIVER_SM</li>
  * <li>UNBIND_RESP, should be called only as response to UNBIND_RESP</li>
@@ -77,83 +72,91 @@ import org.slf4j.LoggerFactory;
  * <li>GENERIC_NACK, should be called only as response to GENERIC_NACK</li>
  * </ul>
  * 
- * All SMPP operation (request-response) is blocking, for an example: SUBMIT_SM
- * will be blocked until SUBMIT_SM_RESP received or timeout. This looks like
- * synchronous communication, but the {@link SMPPClient} implementation give
- * ability to the asynchronous way by executing the SUBMIT_SM operation parallel
- * on a different thread. The very simple implementation by using Thread pool,
- * {@link ExecutorService} will do.
+ * All SMPP operation (request-response) is blocking, for an example: SUBMIT_SM will be blocked until SUBMIT_SM_RESP
+ * received or timeout. This looks like synchronous communication, but the {@link SMPPClient} implementation give
+ * ability to the asynchronous way by executing the SUBMIT_SM operation parallel on a different thread. The very simple
+ * implementation by using Thread pool, {@link ExecutorService} will do.
  * 
- * To receive the incoming message such as DELIVER_SM or DATA_SM will be managed
- * by internal thread. User code only have to set listener
- * {@link MessageReceiverListener}.
+ * To receive the incoming message such as DELIVER_SM or DATA_SM will be managed by internal thread. User code only have
+ * to set listener {@link MessageReceiverListener}.
  * 
  * @author uudashr
  * 
  */
 public class SMPPSession extends AbstractSession implements ClientSession {
-	private static final Logger logger = LoggerFactory.getLogger(SMPPSession.class);
+    private static final Logger logger = LoggerFactory.getLogger(SMPPSession.class);
 
-	/* Utility */
+    /* Utility */
     private final PDUReader pduReader;
-	
+
     /* Connection */
-	private final ConnectionFactory connFactory;
-	private Connection conn;
-	private DataInputStream in;
-	private OutputStream out;
-	
-	private PDUReaderWorker pduReaderWorker;
-	private final ResponseHandler responseHandler = new ResponseHandlerImpl();
-	private MessageReceiverListener messageReceiverListener;
+    private final ConnectionFactory connFactory;
+    private Connection conn;
+    private DataInputStream in;
+    private OutputStream out;
+
+    private PDUReaderWorker pduReaderWorker;
+    private final ResponseHandler responseHandler = new ResponseHandlerImpl();
+    private MessageReceiverListener messageReceiverListener;
     private BoundSessionStateListener sessionStateListener = new BoundSessionStateListener();
     private SMPPSessionContext sessionContext = new SMPPSessionContext(this, sessionStateListener);
-	
-	/**
-     * Default constructor of {@link SMPPSession}. The next action might be
-     * connect and bind to a destination message center.
+
+    /**
+     * Default constructor of {@link SMPPSession}. The next action might be connect and bind to a destination message
+     * center.
      * 
      * @see #connectAndBind(String, int, BindType, String, String, String, TypeOfNumber, NumberingPlanIndicator, String)
      */
-	public SMPPSession() {
-        this(new SynchronizedPDUSender(new DefaultPDUSender(new DefaultComposer())), 
-                new DefaultPDUReader(), 
+    public SMPPSession() {
+        this(new SynchronizedPDUSender(new DefaultPDUSender(new DefaultComposer())),
+                new DefaultPDUReader(),
                 SocketConnectionFactory.getInstance());
     }
-	
-	public SMPPSession(PDUSender pduSender, PDUReader pduReader, 
-	        ConnectionFactory connFactory) {
-	    super(pduSender);
-	    this.pduReader = pduReader;
-	    this.connFactory = connFactory;
+
+    public SMPPSession(PDUSender pduSender, PDUReader pduReader,
+            ConnectionFactory connFactory) {
+        super(pduSender);
+        this.pduReader = pduReader;
+        this.connFactory = connFactory;
     }
-	
-	public SMPPSession(String host, int port, BindParameter bindParam,
+
+    public SMPPSession(String host, int port, BindParameter bindParam,
             PDUSender pduSender, PDUReader pduReader,
             ConnectionFactory connFactory) throws IOException {
-	    this(pduSender, pduReader, connFactory);
-	    connectAndBind(host, port, bindParam);
-	}
-	
-	public SMPPSession(String host, int port, BindParameter bindParam) throws IOException {
+        this(pduSender, pduReader, connFactory);
+        connectAndBind(host, port, bindParam);
+    }
+
+    public SMPPSession(String host, int port, BindParameter bindParam) throws IOException {
         this();
         connectAndBind(host, port, bindParam);
     }
-	
-	/**
+
+    /**
      * Open connection and bind immediately.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindType is the bind type.
-     * @param systemId is the system id.
-     * @param password is the password.
-     * @param systemType is the system type.
-     * @param addrTon is the address TON.
-     * @param addrNpi is the address NPI.
-     * @param addressRange is the address range.
-     * @throws IOException if there is an IO error found.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindType
+     *            is the bind type.
+     * @param systemId
+     *            is the system id.
+     * @param password
+     *            is the password.
+     * @param systemType
+     *            is the system type.
+     * @param addrTon
+     *            is the address TON.
+     * @param addrNpi
+     *            is the address NPI.
+     * @param addressRange
+     *            is the address range.
+     * @throws IOException
+     *             if there is an IO error found.
      */
+    @Override
     public void connectAndBind(String host, int port, BindType bindType,
             String systemId, String password, String systemType,
             TypeOfNumber addrTon, NumberingPlanIndicator addrNpi,
@@ -161,150 +164,193 @@ public class SMPPSession extends AbstractSession implements ClientSession {
         connectAndBind(host, port, new BindParameter(bindType, systemId,
                 password, systemType, addrTon, addrNpi, addressRange), 60000);
     }
-	
-	/**
-     * Open connection and bind immediately with specified timeout. The default
-     * timeout is 1 minutes.
+
+    /**
+     * Open connection and bind immediately with specified timeout. The default timeout is 1 minutes.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindType is the bind type.
-     * @param systemId is the system id.
-     * @param password is the password.
-     * @param systemType is the system type.
-     * @param addrTon is the address TON.
-     * @param addrNpi is the address NPI.
-     * @param addressRange is the address range.
-     * @param timeout is the timeout.
-     * @throws IOException if there is an IO error found.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindType
+     *            is the bind type.
+     * @param systemId
+     *            is the system id.
+     * @param password
+     *            is the password.
+     * @param systemType
+     *            is the system type.
+     * @param addrTon
+     *            is the address TON.
+     * @param addrNpi
+     *            is the address NPI.
+     * @param addressRange
+     *            is the address range.
+     * @param timeout
+     *            is the timeout.
+     * @throws IOException
+     *             if there is an IO error found.
      */
-	public void connectAndBind(String host, int port, BindType bindType,
+    @Override
+    public void connectAndBind(String host, int port, BindType bindType,
             String systemId, String password, String systemType,
             TypeOfNumber addrTon, NumberingPlanIndicator addrNpi,
             String addressRange, long timeout) throws IOException {
-	    connectAndBind(host, port, new BindParameter(bindType, systemId,
+        connectAndBind(host, port, new BindParameter(bindType, systemId,
                 password, systemType, addrTon, addrNpi, addressRange), timeout);
-	}
-	
-	/**
+    }
+
+    /**
      * Open connection and bind immediately.
      * 
-     * @param host is the SMSC host address.
-     * @param port is the SMSC listen port.
-     * @param bindParam is the bind parameters.
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindParam
+     *            is the bind parameters.
      * @return the SMSC system id.
-     * @throws IOException if there is an IO error found.
+     * @throws IOException
+     *             if there is an IO error found.
      */
+    @Override
     public String connectAndBind(String host, int port,
-            BindParameter bindParam) 
+            BindParameter bindParam)
             throws IOException {
         return connectAndBind(host, port, bindParam, 60000);
     }
-	
-	/**
-	 * Open connection and bind immediately.
-	 * 
-	 * @param host is the SMSC host address.
-	 * @param port is the SMSC listen port.
-	 * @param bindParam is the bind parameters.
-	 * @param timeout is the timeout.
-	 * @return the SMSC system id.
-	 * @throws IOException if there is an IO error found.
-	 */
-	public String connectAndBind(String host, int port,
-            BindParameter bindParam, long timeout) 
-	        throws IOException {
-	    logger.debug("Connect and bind to {} port {}", host, port);
-		if (sequence().currentValue() != 1) {
-			throw new IOException("Failed connecting");
-		}
-		
-		conn = connFactory.createConnection(host, port);
-		logger.info("Connected");
-		
-		conn.setSoTimeout(getEnquireLinkTimer());
-		
-		sessionContext.open();
-		try {
-			in = new DataInputStream(conn.getInputStream());
-			out = conn.getOutputStream();
-			
-			pduReaderWorker = new PDUReaderWorker();
-			pduReaderWorker.start();
-			String smscSystemId = sendBind(bindParam.getBindType(), bindParam.getSystemId(), bindParam.getPassword(), bindParam.getSystemType(),
+
+    /**
+     * Open connection and bind immediately.
+     * 
+     * @param host
+     *            is the SMSC host address.
+     * @param port
+     *            is the SMSC listen port.
+     * @param bindParam
+     *            is the bind parameters.
+     * @param timeout
+     *            is the timeout.
+     * @return the SMSC system id.
+     * @throws IOException
+     *             if there is an IO error found.
+     */
+    @Override
+    public String connectAndBind(String host, int port,
+            BindParameter bindParam, long timeout)
+            throws IOException {
+        SMPPSession.logger.debug("Connect and bind to {} port {}", host, port);
+        if (sequence().currentValue() != 1) {
+            throw new IOException("Failed connecting");
+        }
+
+        conn = connFactory.createConnection(host, port);
+        SMPPSession.logger.info("Connected");
+
+        conn.setSoTimeout(getEnquireLinkTimer());
+
+        sessionContext.open();
+        try {
+            in = new DataInputStream(conn.getInputStream());
+            out = conn.getOutputStream();
+
+            pduReaderWorker = new PDUReaderWorker();
+            pduReaderWorker.start();
+            String smscSystemId = sendBind(bindParam.getBindType(), bindParam.getSystemId(), bindParam.getPassword(), bindParam.getSystemType(),
                     bindParam.getInterfaceVersion(), bindParam.getAddrTon(), bindParam.getAddrNpi(), bindParam.getAddressRange(), timeout);
-			sessionContext.bound(bindParam.getBindType());
-			
-			enquireLinkSender = new EnquireLinkSender();
-			enquireLinkSender.start();
-			return smscSystemId;
-		} catch (PDUException e) {
-		    logger.error("Failed sending bind command", e);
-		    throw new IOException("Failed sending bind since some string parameter area invalid : " + e.getMessage(), e);
-		} catch (NegativeResponseException e) {
-			String message = "Receive negative bind response";
-			logger.error(message, e);
-			close();
-			throw new IOException(message + ": " + e.getMessage(), e);
-		} catch (InvalidResponseException e) {
-			String message = "Receive invalid response of bind";
-			logger.error(message, e);
-			close();
-			throw new IOException(message + ": " + e.getMessage(), e);
-		} catch (ResponseTimeoutException e) {
-			String message = "Waiting bind response take time to long";
-			logger.error(message, e);
-			close();
-			throw new IOException(message + ": " + e.getMessage(), e);
-		} catch (IOException e) {
-			logger.error("IO Error occur", e);
-			close();
-			throw e;
-		}
-	}
-	
-	/**
-	 * Sending bind.
-	 * 
-	 * @param bindType is the bind type.
-	 * @param systemId is the system id.
-	 * @param password is the password.
-	 * @param systemTypeis the system type.
-	 * @param interfaceVersion is the interface version.
-	 * @param addrTon is the address TON.
-	 * @param addrNpi is the address NPI.
-	 * @param addressRange is the address range.
-	 * @param timeout is the max time waiting for bind response. 
-	 * @return SMSC system id.
-	 * @throws PDUException if we enter invalid bind parameter(s).
-	 * @throws ResponseTimeoutException if there is no valid response after defined millisecond.
-	 * @throws InvalidResponseException if there is invalid response found.
-	 * @throws NegativeResponseException if we receive negative response.
-	 * @throws IOException if there is an IO error occur.
-	 */
-	private String sendBind(BindType bindType, String systemId,
-			String password, String systemType,
-			InterfaceVersion interfaceVersion, TypeOfNumber addrTon,
-			NumberingPlanIndicator addrNpi, String addressRange, long timeout)
-			throws PDUException, ResponseTimeoutException,
-			InvalidResponseException, NegativeResponseException, IOException {
-	    
-	    BindCommandTask task = new BindCommandTask(pduSender(), bindType,
+            sessionContext.bound(bindParam.getBindType());
+
+            enquireLinkSender = new EnquireLinkSender();
+            enquireLinkSender.start();
+            return smscSystemId;
+        } catch (PDUException e) {
+            SMPPSession.logger.error("Failed sending bind command", e);
+            throw new IOException("Failed sending bind since some string parameter area invalid : " + e.getMessage(), e);
+        } catch (NegativeResponseException e) {
+            String message = "Receive negative bind response";
+            SMPPSession.logger.error(message, e);
+            close();
+            throw new IOException(message + ": " + e.getMessage(), e);
+        } catch (InvalidResponseException e) {
+            String message = "Receive invalid response of bind";
+            SMPPSession.logger.error(message, e);
+            close();
+            throw new IOException(message + ": " + e.getMessage(), e);
+        } catch (ResponseTimeoutException e) {
+            String message = "Waiting bind response take time to long";
+            SMPPSession.logger.error(message, e);
+            close();
+            throw new IOException(message + ": " + e.getMessage(), e);
+        } catch (IOException e) {
+            SMPPSession.logger.error("IO Error occur", e);
+            close();
+            throw e;
+        }
+    }
+
+    /**
+     * Sending bind.
+     * 
+     * @param bindType
+     *            is the bind type.
+     * @param systemId
+     *            is the system id.
+     * @param password
+     *            is the password.
+     * @param systemTypeis
+     *            the system type.
+     * @param interfaceVersion
+     *            is the interface version.
+     * @param addrTon
+     *            is the address TON.
+     * @param addrNpi
+     *            is the address NPI.
+     * @param addressRange
+     *            is the address range.
+     * @param timeout
+     *            is the max time waiting for bind response.
+     * @return SMSC system id.
+     * @throws PDUException
+     *             if we enter invalid bind parameter(s).
+     * @throws ResponseTimeoutException
+     *             if there is no valid response after defined millisecond.
+     * @throws InvalidResponseException
+     *             if there is invalid response found.
+     * @throws NegativeResponseException
+     *             if we receive negative response.
+     * @throws IOException
+     *             if there is an IO error occur.
+     */
+    private String sendBind(BindType bindType, String systemId,
+            String password, String systemType,
+            InterfaceVersion interfaceVersion, TypeOfNumber addrTon,
+            NumberingPlanIndicator addrNpi, String addressRange, long timeout)
+            throws PDUException, ResponseTimeoutException,
+            InvalidResponseException, NegativeResponseException, IOException {
+
+        BindCommandTask task = new BindCommandTask(pduSender(), bindType,
                 systemId, password, systemType, interfaceVersion, addrTon,
                 addrNpi, addressRange);
-	    
-	    BindResp resp = (BindResp)executeSendCommand(task, timeout);
-	    OptionalParameter.Sc_interface_version sc_version = resp.getOptionalParameter(Sc_interface_version.class);
-	    if(sc_version != null) {
-		    logger.info("Other side reports smpp interface version {}", sc_version);
-	    }
-        
-		return resp.getSystemId();
-	}
-	
-    /* (non-Javadoc)
-     * @see org.jsmpp.session.ClientSession#submitShortMessage(java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.ESMClass, byte, byte, java.lang.String, java.lang.String, org.jsmpp.bean.RegisteredDelivery, byte, org.jsmpp.bean.DataCoding, byte, byte[], org.jsmpp.bean.OptionalParameter[])
+
+        BindResp resp = (BindResp) executeSendCommand(task, timeout);
+        OptionalParameter.Sc_interface_version sc_version = resp.getOptionalParameter(Sc_interface_version.class);
+        if (sc_version != null) {
+            SMPPSession.logger.info("Other side reports smpp interface version {}", sc_version);
+        }
+
+        return resp.getSystemId();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jsmpp.session.ClientSession#submitShortMessage(java.lang.String, org.jsmpp.bean.TypeOfNumber,
+     * org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.TypeOfNumber,
+     * org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.ESMClass, byte, byte, java.lang.String,
+     * java.lang.String, org.jsmpp.bean.RegisteredDelivery, byte, org.jsmpp.bean.DataCoding, byte, byte[],
+     * org.jsmpp.bean.OptionalParameter[])
      */
+    @Override
     public String submitShortMessage(String serviceType,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
             String sourceAddr, TypeOfNumber destAddrTon,
@@ -316,23 +362,29 @@ public class SMPPSession extends AbstractSession implements ClientSession {
             OptionalParameter... optionalParameters) throws PDUException,
             ResponseTimeoutException, InvalidResponseException,
             NegativeResponseException, IOException {
-    	
+
         ensureTransmittable("submitShortMessage");
-    	
+
         SubmitSmCommandTask submitSmTask = new SubmitSmCommandTask(
                 pduSender(), serviceType, sourceAddrTon, sourceAddrNpi,
                 sourceAddr, destAddrTon, destAddrNpi, destinationAddr,
                 esmClass, protocolId, priorityFlag, scheduleDeliveryTime,
                 validityPeriod, registeredDelivery, replaceIfPresentFlag,
                 dataCoding, smDefaultMsgId, shortMessage, optionalParameters);
-    	
-        SubmitSmResp resp = (SubmitSmResp)executeSendCommand(submitSmTask, getTransactionTimer());
-    	return resp.getMessageId();
+
+        SubmitSmResp resp = (SubmitSmResp) executeSendCommand(submitSmTask, getTransactionTimer());
+        return resp.getMessageId();
     }
-    
-    /* (non-Javadoc)
-     * @see org.jsmpp.session.ClientSession#submitMultiple(java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.Address[], org.jsmpp.bean.ESMClass, byte, byte, java.lang.String, java.lang.String, org.jsmpp.bean.RegisteredDelivery, org.jsmpp.bean.ReplaceIfPresentFlag, org.jsmpp.bean.DataCoding, byte, byte[], org.jsmpp.bean.OptionalParameter[])
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jsmpp.session.ClientSession#submitMultiple(java.lang.String, org.jsmpp.bean.TypeOfNumber,
+     * org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.Address[], org.jsmpp.bean.ESMClass, byte,
+     * byte, java.lang.String, java.lang.String, org.jsmpp.bean.RegisteredDelivery, org.jsmpp.bean.ReplaceIfPresentFlag,
+     * org.jsmpp.bean.DataCoding, byte, byte[], org.jsmpp.bean.OptionalParameter[])
      */
+    @Override
     public SubmitMultiResult submitMultiple(String serviceType,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
             String sourceAddr, Address[] destinationAddresses,
@@ -344,9 +396,9 @@ public class SMPPSession extends AbstractSession implements ClientSession {
             OptionalParameter... optionalParameters) throws PDUException,
             ResponseTimeoutException, InvalidResponseException,
             NegativeResponseException, IOException {
-        
+
         ensureTransmittable("submitMultiple");
-        
+
         SubmitMultiCommandTask task = new SubmitMultiCommandTask(pduSender(),
                 serviceType, sourceAddrTon, sourceAddrNpi, sourceAddr,
                 destinationAddresses, esmClass, protocolId, priorityFlag,
@@ -354,27 +406,43 @@ public class SMPPSession extends AbstractSession implements ClientSession {
                 replaceIfPresentFlag, dataCoding, smDefaultMsgId, shortMessage,
                 optionalParameters);
 
-        SubmitMultiResp resp = (SubmitMultiResp)executeSendCommand(task,
+        SubmitMultiResp resp = (SubmitMultiResp) executeSendCommand(task,
                 getTransactionTimer());
 
         return new SubmitMultiResult(resp.getMessageId(), resp
                 .getUnsuccessSmes());
     }
-    
-    /* (non-Javadoc)
-     * @see org.jsmpp.session.ClientSession#queryShortMessage(java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String)
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jsmpp.session.ClientSession#sendDeliverSmResp(org.jsmpp.bean.DeliverSm)
      */
+    @Override
+    public void sendDeliverSmResp(DeliverSm deliverSm) throws PDUException, ResponseTimeoutException,
+            InvalidResponseException, NegativeResponseException, IOException {
+        pduSender().sendDeliverSmResp(out, 0 /* deliverSm.getCommandStatus() */, deliverSm.getSequenceNumber());
+        SMPPSession.logger.debug("deliver_sm_resp with seq_number " + deliverSm.getSequenceNumber() + " has been sent");
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jsmpp.session.ClientSession#queryShortMessage(java.lang.String, org.jsmpp.bean.TypeOfNumber,
+     * org.jsmpp.bean.NumberingPlanIndicator, java.lang.String)
+     */
+    @Override
     public QuerySmResult queryShortMessage(String messageId,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
             String sourceAddr) throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException {
-        
+
         ensureTransmittable("queryShortMessage");
-        
+
         QuerySmCommandTask task = new QuerySmCommandTask(pduSender(),
                 messageId, sourceAddrTon, sourceAddrNpi, sourceAddr);
-        
-        QuerySmResp resp = (QuerySmResp)executeSendCommand(task,
+
+        QuerySmResp resp = (QuerySmResp) executeSendCommand(task,
                 getTransactionTimer());
 
         if (resp.getMessageId().equals(messageId)) {
@@ -386,10 +454,15 @@ public class SMPPSession extends AbstractSession implements ClientSession {
                     "Requested message_id doesn't match with the result");
         }
     }
-    
-    /* (non-Javadoc)
-     * @see org.jsmpp.session.ClientSession#replaceShortMessage(java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, java.lang.String, java.lang.String, org.jsmpp.bean.RegisteredDelivery, byte, byte[])
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jsmpp.session.ClientSession#replaceShortMessage(java.lang.String, org.jsmpp.bean.TypeOfNumber,
+     * org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, java.lang.String, java.lang.String,
+     * org.jsmpp.bean.RegisteredDelivery, byte, byte[])
      */
+    @Override
     public void replaceShortMessage(String messageId,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
             String sourceAddr, String scheduleDeliveryTime,
@@ -397,9 +470,9 @@ public class SMPPSession extends AbstractSession implements ClientSession {
             byte smDefaultMsgId, byte[] shortMessage) throws PDUException,
             ResponseTimeoutException, InvalidResponseException,
             NegativeResponseException, IOException {
-        
+
         ensureTransmittable("replaceShortMessage", true);
-        
+
         ReplaceSmCommandTask replaceSmTask = new ReplaceSmCommandTask(
                 pduSender(), messageId, sourceAddrTon, sourceAddrNpi,
                 sourceAddr, scheduleDeliveryTime, validityPeriod,
@@ -407,277 +480,294 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 
         executeSendCommand(replaceSmTask, getTransactionTimer());
     }
-    
-    /* (non-Javadoc)
-     * @see org.jsmpp.session.ClientSession#cancelShortMessage(java.lang.String, java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String, org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String)
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jsmpp.session.ClientSession#cancelShortMessage(java.lang.String, java.lang.String,
+     * org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String,
+     * org.jsmpp.bean.TypeOfNumber, org.jsmpp.bean.NumberingPlanIndicator, java.lang.String)
      */
+    @Override
     public void cancelShortMessage(String serviceType, String messageId,
             TypeOfNumber sourceAddrTon, NumberingPlanIndicator sourceAddrNpi,
             String sourceAddr, TypeOfNumber destAddrTon,
             NumberingPlanIndicator destAddrNpi, String destinationAddress)
             throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException {
-        
+
         ensureTransmittable("cancelShortMessage");
-        
+
         CancelSmCommandTask task = new CancelSmCommandTask(pduSender(),
                 serviceType, messageId, sourceAddrTon, sourceAddrNpi,
                 sourceAddr, destAddrTon, destAddrNpi, destinationAddress);
-        
+
         executeSendCommand(task, getTransactionTimer());
     }
-    
+
+    @Override
     public MessageReceiverListener getMessageReceiverListener() {
         return messageReceiverListener;
     }
-    
-	public void setMessageReceiverListener(
-			MessageReceiverListener messageReceiverListener) {
-		this.messageReceiverListener = messageReceiverListener;
-	}
-	
-	@Override
-	protected Connection connection() {
-	    return conn;
-	}
-	
-	@Override
-	protected AbstractSessionContext sessionContext() {
-	    return sessionContext;
-	}
-	
-	@Override
-	protected GenericMessageReceiverListener messageReceiverListener() {
-	    return messageReceiverListener;
-	}
-	
-	@Override
-	public void close()
-	{
-		super.close();
 
-		if(Thread.currentThread() != pduReaderWorker) {
-			try {
-				if(pduReaderWorker != null) {
-					pduReaderWorker.join();
-				}
-			} catch (InterruptedException e) {
-				logger.warn("Interrupted while waiting for pduReaderWorker thread to exit");
-			}
-		}
-	}
+    @Override
+    public void setMessageReceiverListener(
+            MessageReceiverListener messageReceiverListener) {
+        this.messageReceiverListener = messageReceiverListener;
+    }
 
-	@Override
-	protected void finalize() throws Throwable {
-		close();
-	}
-	
-	private void fireAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
-		if (messageReceiverListener != null) {
-			messageReceiverListener.onAcceptDeliverSm(deliverSm);
-        } else { 
-			logger.warn("Receive deliver_sm but MessageReceiverListener is null. Short message = " + new String(deliverSm.getShortMessage()));
-			throw new ProcessRequestException("No message receiver listener registered", SMPPConstant.STAT_ESME_RX_T_APPN);
+    @Override
+    protected Connection connection() {
+        return conn;
+    }
+
+    @Override
+    protected AbstractSessionContext sessionContext() {
+        return sessionContext;
+    }
+
+    @Override
+    protected GenericMessageReceiverListener messageReceiverListener() {
+        return messageReceiverListener;
+    }
+
+    @Override
+    public void close()
+    {
+        super.close();
+
+        if (Thread.currentThread() != pduReaderWorker) {
+            try {
+                if (pduReaderWorker != null) {
+                    pduReaderWorker.join();
+                }
+            } catch (InterruptedException e) {
+                SMPPSession.logger.warn("Interrupted while waiting for pduReaderWorker thread to exit");
+            }
         }
-	}
-	
-	private void fireAcceptAlertNotification(AlertNotification alertNotification) {
-	    if (messageReceiverListener != null) {
-	        messageReceiverListener.onAcceptAlertNotification(alertNotification);
-	    } else {
-	        logger.warn("Receive alert_notification but MessageReceiverListener is null");
-	    }
-	}
-	
-	private class ResponseHandlerImpl implements ResponseHandler {
-		
-		public void processDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
-			try {
-				fireAcceptDeliverSm(deliverSm);
-			} catch(ProcessRequestException e) {
-				throw e;
-			} catch(Exception e) {
-				String msg = "Invalid runtime exception thrown when processing DeliverSm";
-				logger.error(msg, e);
-				throw new ProcessRequestException(msg, SMPPConstant.STAT_ESME_RX_T_APPN);
-			}
-		}
-		
-		public DataSmResult processDataSm(DataSm dataSm)
-		        throws ProcessRequestException {
-			try {
-				return fireAcceptDataSm(dataSm);
-			} catch(ProcessRequestException e) {
-				throw e;
-			} catch(Exception e) {
-				String msg = "Invalid runtime exception thrown when processing DataSm";
-				logger.error(msg, e);
-				throw new ProcessRequestException(msg, SMPPConstant.STAT_ESME_RX_T_APPN);
-			}
-		}
-		
-		public void processAlertNotification(AlertNotification alertNotification) {
-			try {
-				fireAcceptAlertNotification(alertNotification);
-			} catch(Exception e) {
-				String msg = "Invalid runtime exception thrown when processing AlertSm";
-				logger.error(msg, e);
-			}
-		}
-		
-		public void sendDataSmResp(DataSmResult dataSmResult, int sequenceNumber)
-		        throws IOException {
-		    try {
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        close();
+    }
+
+    private boolean fireAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
+        if (messageReceiverListener != null) {
+            return messageReceiverListener.onAcceptDeliverSm(deliverSm);
+        } else {
+            SMPPSession.logger.warn("Receive deliver_sm but MessageReceiverListener is null. Short message = " + new String(deliverSm.getShortMessage()));
+            throw new ProcessRequestException("No message receiver listener registered", SMPPConstant.STAT_ESME_RX_T_APPN);
+        }
+    }
+
+    private void fireAcceptAlertNotification(AlertNotification alertNotification) {
+        if (messageReceiverListener != null) {
+            messageReceiverListener.onAcceptAlertNotification(alertNotification);
+        } else {
+            SMPPSession.logger.warn("Receive alert_notification but MessageReceiverListener is null");
+        }
+    }
+
+    private class ResponseHandlerImpl implements ResponseHandler {
+
+        @Override
+        public boolean processDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
+            try {
+                return fireAcceptDeliverSm(deliverSm);
+            } catch (ProcessRequestException e) {
+                throw e;
+            } catch (Exception e) {
+                String msg = "Invalid runtime exception thrown when processing DeliverSm";
+                SMPPSession.logger.error(msg, e);
+                throw new ProcessRequestException(msg, SMPPConstant.STAT_ESME_RX_T_APPN);
+            }
+        }
+
+        @Override
+        public DataSmResult processDataSm(DataSm dataSm)
+                throws ProcessRequestException {
+            try {
+                return fireAcceptDataSm(dataSm);
+            } catch (ProcessRequestException e) {
+                throw e;
+            } catch (Exception e) {
+                String msg = "Invalid runtime exception thrown when processing DataSm";
+                SMPPSession.logger.error(msg, e);
+                throw new ProcessRequestException(msg, SMPPConstant.STAT_ESME_RX_T_APPN);
+            }
+        }
+
+        @Override
+        public void processAlertNotification(AlertNotification alertNotification) {
+            try {
+                fireAcceptAlertNotification(alertNotification);
+            } catch (Exception e) {
+                String msg = "Invalid runtime exception thrown when processing AlertSm";
+                SMPPSession.logger.error(msg, e);
+            }
+        }
+
+        @Override
+        public void sendDataSmResp(DataSmResult dataSmResult, int sequenceNumber)
+                throws IOException {
+            try {
                 pduSender().sendDataSmResp(out, sequenceNumber,
                         dataSmResult.getMessageId(),
                         dataSmResult.getOptionalParameters());
             } catch (PDUStringException e) {
                 /*
-                 * There should be no PDUStringException thrown since creation
-                 * of MessageId should be save.
+                 * There should be no PDUStringException thrown since creation of MessageId should be save.
                  */
-                logger.error("SYSTEM ERROR. Failed sending dataSmResp", e);
+                SMPPSession.logger.error("SYSTEM ERROR. Failed sending dataSmResp", e);
             }
-		}
-		
-		public PendingResponse<Command> removeSentItem(int sequenceNumber) {
-			return removePendingResponse(sequenceNumber);
-		}
-		
-		public void notifyUnbonded() {
-		    sessionContext.unbound();
-		}
-		
-		public void sendDeliverSmResp(int commandStatus, int sequenceNumber) throws IOException {
-			pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber);
-			logger.debug("deliver_sm_resp with seq_number " + sequenceNumber + " has been sent");
-		}
-		
-		public void sendEnquireLinkResp(int sequenceNumber) throws IOException {
-		    logger.debug("Sending enquire_link_resp");
-			pduSender().sendEnquireLinkResp(out, sequenceNumber);
-		}
-		
-		public void sendGenerickNack(int commandStatus, int sequenceNumber) throws IOException {
-			pduSender().sendGenericNack(out, commandStatus, sequenceNumber);
-		}
-		
-		public void sendNegativeResponse(int originalCommandId, int commandStatus, int sequenceNumber) throws IOException {
-			pduSender().sendHeader(out, originalCommandId | SMPPConstant.MASK_CID_RESP, commandStatus, sequenceNumber);
-		}
-		
-		public void sendUnbindResp(int sequenceNumber) throws IOException {
-			pduSender().sendUnbindResp(out, SMPPConstant.STAT_ESME_ROK, sequenceNumber);
-		}
-	}
-	
-	/**
-	 * Worker to read the PDU.
-	 * 
-	 * @author uudashr
-	 *
-	 */
-	private class PDUReaderWorker extends Thread {
-		// start with serial execution of pdu processing, when the session is bound the pool will be enlarge up to the PduProcessorDegree
-	    private ExecutorService executorService = Executors.newFixedThreadPool(1); 
-		
-	    public PDUReaderWorker() {
-        	super("PDUReaderWorker: " + SMPPSession.this);
-	    }
-	    
-	    private Runnable onIOExceptionTask = new Runnable() {
-		    public void run() {
-		        close();
-		    };
-		};
-		
-	    @Override
-		public void run() {
-	        logger.info("Starting PDUReaderWorker");
-			while (isReadPdu()) {
+        }
+
+        @Override
+        public PendingResponse<Command> removeSentItem(int sequenceNumber) {
+            return removePendingResponse(sequenceNumber);
+        }
+
+        @Override
+        public void notifyUnbonded() {
+            sessionContext.unbound();
+        }
+
+        @Override
+        public void sendDeliverSmResp(int commandStatus, int sequenceNumber) throws IOException {
+            pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber);
+            SMPPSession.logger.debug("deliver_sm_resp with seq_number " + sequenceNumber + " has been sent");
+        }
+
+        @Override
+        public void sendEnquireLinkResp(int sequenceNumber) throws IOException {
+            SMPPSession.logger.debug("Sending enquire_link_resp");
+            pduSender().sendEnquireLinkResp(out, sequenceNumber);
+        }
+
+        @Override
+        public void sendGenerickNack(int commandStatus, int sequenceNumber) throws IOException {
+            pduSender().sendGenericNack(out, commandStatus, sequenceNumber);
+        }
+
+        @Override
+        public void sendNegativeResponse(int originalCommandId, int commandStatus, int sequenceNumber) throws IOException {
+            pduSender().sendHeader(out, originalCommandId | SMPPConstant.MASK_CID_RESP, commandStatus, sequenceNumber);
+        }
+
+        @Override
+        public void sendUnbindResp(int sequenceNumber) throws IOException {
+            pduSender().sendUnbindResp(out, SMPPConstant.STAT_ESME_ROK, sequenceNumber);
+        }
+    }
+
+    /**
+     * Worker to read the PDU.
+     * 
+     * @author uudashr
+     * 
+     */
+    private class PDUReaderWorker extends Thread {
+        // start with serial execution of pdu processing, when the session is bound the pool will be enlarge up to the
+        // PduProcessorDegree
+        private ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        public PDUReaderWorker() {
+            super("PDUReaderWorker: " + SMPPSession.this);
+        }
+
+        private Runnable onIOExceptionTask = new Runnable() {
+            @Override
+            public void run() {
+                close();
+            };
+        };
+
+        @Override
+        public void run() {
+            SMPPSession.logger.info("Starting PDUReaderWorker");
+            while (isReadPdu()) {
                 readPDU();
-			}
-			close();
-			executorService.shutdown();
-			try {
-				executorService.awaitTermination(getTransactionTimer(), TimeUnit.MILLISECONDS);
-			} catch (InterruptedException e) {
-				logger.warn("interrupted while waiting for executor service pool to finish");
-			}
-			logger.info("PDUReaderWorker stop");
-		}
-		
-		private void readPDU() {
-	        try {
-	            Command pduHeader = null;
-	            byte[] pdu = null;
-	            
+            }
+            close();
+            executorService.shutdown();
+            try {
+                executorService.awaitTermination(getTransactionTimer(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                SMPPSession.logger.warn("interrupted while waiting for executor service pool to finish");
+            }
+            SMPPSession.logger.info("PDUReaderWorker stop");
+        }
+
+        private void readPDU() {
+            try {
+                Command pduHeader = null;
+                byte[] pdu = null;
+
                 pduHeader = pduReader.readPDUHeader(in);
                 pdu = pduReader.readPDU(in, pduHeader);
-	            
+
                 /*
-                 * When the processing PDU is need user interaction via event,
-                 * the code on event might take non-short time, so we need to
-                 * process it concurrently.
+                 * When the processing PDU is need user interaction via event, the code on event might take non-short
+                 * time, so we need to process it concurrently.
                  */
                 PDUProcessTask task = new PDUProcessTask(pduHeader, pdu,
                         sessionContext, responseHandler,
                         sessionContext, onIOExceptionTask);
-	            executorService.execute(task);
-	            
-	        } catch (InvalidCommandLengthException e) {
-	            logger.warn("Receive invalid command length", e);
-	            try {
-	                pduSender().sendGenericNack(out, SMPPConstant.STAT_ESME_RINVCMDLEN, 0);
-	            } catch (IOException ee) {
-	                logger.warn("Failed sending generic nack", ee);
-	            }
-	            unbindAndClose();
-	        } catch (SocketTimeoutException e) {
-	            notifyNoActivity();
-	        } catch (IOException e) {
-	            logger.warn("IOException while reading: {}", e.getMessage());
-	            close();
-	        }
-	    }
-		
-	    /**
-	     * Notify for no activity.
-	     */
-	    private void notifyNoActivity() {
-	        logger.debug("No activity notified, sending enquireLink");
-	        if (sessionContext().getSessionState().isBound()) {
-	            enquireLinkSender.enquireLink();
-	        }
-	    }
-	}
+                executorService.execute(task);
 
-	
-	/**
-	 * Session state listener for internal class use.
-	 * 
-	 * @author uudashr
-	 *
-	 */
-	private class BoundSessionStateListener implements SessionStateListener {
-	    public void onStateChange(SessionState newState, SessionState oldState,
-	    		Session source) {
-	        /*
-	         * We need to set SO_TIMEOUT to sessionTimer so when timeout occur, 
-	         * a SocketTimeoutException will be raised. When Exception raised we
-	         * can send an enquireLinkCommand.
-	         */
-	        if (newState.isBound()) {
-	            try {
+            } catch (InvalidCommandLengthException e) {
+                SMPPSession.logger.warn("Receive invalid command length", e);
+                try {
+                    pduSender().sendGenericNack(out, SMPPConstant.STAT_ESME_RINVCMDLEN, 0);
+                } catch (IOException ee) {
+                    SMPPSession.logger.warn("Failed sending generic nack", ee);
+                }
+                unbindAndClose();
+            } catch (SocketTimeoutException e) {
+                notifyNoActivity();
+            } catch (IOException e) {
+                SMPPSession.logger.warn("IOException while reading: {}", e.getMessage());
+                close();
+            }
+        }
+
+        /**
+         * Notify for no activity.
+         */
+        private void notifyNoActivity() {
+            SMPPSession.logger.debug("No activity notified, sending enquireLink");
+            if (sessionContext().getSessionState().isBound()) {
+                enquireLinkSender.enquireLink();
+            }
+        }
+    }
+
+    /**
+     * Session state listener for internal class use.
+     * 
+     * @author uudashr
+     * 
+     */
+    private class BoundSessionStateListener implements SessionStateListener {
+        @Override
+        public void onStateChange(SessionState newState, SessionState oldState,
+                Session source) {
+            /*
+             * We need to set SO_TIMEOUT to sessionTimer so when timeout occur, a SocketTimeoutException will be raised.
+             * When Exception raised we can send an enquireLinkCommand.
+             */
+            if (newState.isBound()) {
+                try {
                     conn.setSoTimeout(getEnquireLinkTimer());
                 } catch (IOException e) {
-                    logger.error("Failed setting so_timeout for session timer", e);
+                    SMPPSession.logger.error("Failed setting so_timeout for session timer", e);
                 }
-    	        
-               	logger.info("Changing processor degree to {}", getPduProcessorDegree());
-               	((ThreadPoolExecutor)pduReaderWorker.executorService).setCorePoolSize(getPduProcessorDegree());
-               	((ThreadPoolExecutor)pduReaderWorker.executorService).setMaximumPoolSize(getPduProcessorDegree());
-	        }
-	    }
-	}
+
+                SMPPSession.logger.info("Changing processor degree to {}", getPduProcessorDegree());
+                ((ThreadPoolExecutor) pduReaderWorker.executorService).setCorePoolSize(getPduProcessorDegree());
+                ((ThreadPoolExecutor) pduReaderWorker.executorService).setMaximumPoolSize(getPduProcessorDegree());
+            }
+        }
+    }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -421,6 +421,8 @@ public class SMPPSession extends AbstractSession implements ClientSession {
     @Override
     public void sendDeliverSmResp(DeliverSm deliverSm) throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException {
+        ensureTransmittable("deliverSmResp");
+
         pduSender().sendDeliverSmResp(out, 0 /* deliverSm.getCommandStatus() */, deliverSm.getSequenceNumber());
         SMPPSession.logger.debug("deliver_sm_resp with seq_number " + deliverSm.getSequenceNumber() + " has been sent");
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -37,6 +37,7 @@ import org.jsmpp.bean.Command;
 import org.jsmpp.bean.DataCoding;
 import org.jsmpp.bean.DataSm;
 import org.jsmpp.bean.DeliverSm;
+import org.jsmpp.bean.DeliverSmResp;
 import org.jsmpp.bean.ESMClass;
 import org.jsmpp.bean.InterfaceVersion;
 import org.jsmpp.bean.NumberingPlanIndicator;
@@ -416,15 +417,15 @@ public class SMPPSession extends AbstractSession implements ClientSession {
     /*
      * (non-Javadoc)
      * 
-     * @see org.jsmpp.session.ClientSession#sendDeliverSmResp(org.jsmpp.bean.DeliverSm)
+     * @see org.jsmpp.session.ClientSession#sendDeliverSmResp(org.jsmpp.bean.DeliverSmResp)
      */
     @Override
-    public void sendDeliverSmResp(DeliverSm deliverSm) throws PDUException, ResponseTimeoutException,
+    public void sendDeliverSmResp(DeliverSmResp deliverSmResp) throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException {
         ensureTransmittable("deliverSmResp");
 
-        pduSender().sendDeliverSmResp(out, 0 /* deliverSm.getCommandStatus() */, deliverSm.getSequenceNumber());
-        SMPPSession.logger.debug("deliver_sm_resp with seq_number " + deliverSm.getSequenceNumber() + " has been sent");
+        pduSender().sendDeliverSmResp(out, deliverSmResp.getCommandStatus(), deliverSmResp.getSequenceNumber());
+        SMPPSession.logger.debug("deliver_sm_resp with seq_number " + deliverSmResp.getSequenceNumber() + " has been sent");
     }
 
     /*

--- a/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SocketConnection.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SocketConnection.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.connection.socket;
 
@@ -20,7 +16,6 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 
-import org.jsmpp.session.SMPPSession;
 import org.jsmpp.session.connection.Connection;
 import org.jsmpp.util.StrictBufferedInputStream;
 import org.slf4j.Logger;
@@ -28,45 +23,51 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author uudashr
- *
+ * 
  */
 public class SocketConnection implements Connection {
-	private static final Logger logger = LoggerFactory.getLogger(SocketConnection.class);
-    
+    private static final Logger logger = LoggerFactory.getLogger(SocketConnection.class);
+
     private final Socket socket;
     private final InputStream in;
     private final OutputStream out;
-    
+
     public SocketConnection(Socket socket) throws IOException {
         this.socket = socket;
-        this.in = new StrictBufferedInputStream(socket.getInputStream(), 65536);// 64 KB buffer
-        this.out = socket.getOutputStream();
+        in = new StrictBufferedInputStream(socket.getInputStream(), 65536);// 64 KB buffer
+        out = socket.getOutputStream();
     }
-    
+
+    @Override
     public void setSoTimeout(int timeout) throws IOException {
         socket.setSoTimeout(timeout);
     }
-    
+
+    @Override
     public void close() {
         try {
             socket.close();
         } catch (IOException e) {
-        	logger.warn("Suppressing IOException while closing socket: " + e);
+            SocketConnection.logger.warn("Suppressing IOException while closing socket: " + e);
         }
     }
-    
+
+    @Override
     public boolean isOpen() {
         return !socket.isClosed();
     }
-    
+
+    @Override
     public InputStream getInputStream() {
         return in;
     }
-    
+
+    @Override
     public OutputStream getOutputStream() {
         return out;
     }
-    
+
+    @Override
     public InetAddress getInetAddress() {
         return socket.getInetAddress();
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/AbstractGenericSMPPSessionBound.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/AbstractGenericSMPPSessionBound.java
@@ -61,7 +61,7 @@ abstract class AbstractGenericSMPPSessionBound implements GenericSMPPSessionStat
 
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        logger.info("Receving unbind request");
+        logger.info("Receiving unbind request");
         try {
             responseHandler.sendUnbindResp(pduHeader.getSequenceNumber());
         } finally {

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionBoundRX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionBoundRX.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -27,66 +23,54 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author uudashr
- *
+ * 
  */
-class SMPPServerSessionBoundRX extends SMPPServerSessionBound implements
-        SMPPServerSessionState {
+class SMPPServerSessionBoundRX extends SMPPServerSessionBound implements SMPPServerSessionState {
     private static final Logger logger = LoggerFactory.getLogger(SMPPServerSessionBoundRX.class);
-    
+
+    @Override
     public SessionState getSessionState() {
         return SessionState.BOUND_RX;
     }
-    
-    public void processDeliverSmResp(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
-        processDeliverSmResp0(pduHeader, pdu, responseHandler);
+
+    @Override
+    public void processDeliverSmResp(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
+        SMPPServerSessionBoundRX.processDeliverSmResp0(pduHeader, pdu, responseHandler);
     }
 
-    public void processQuerySm(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+    @Override
+    public void processQuerySm(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
 
-    public void processSubmitSm(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+    @Override
+    public void processSubmitSm(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processSubmitMulti(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processSubmitMulti(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processCancelSm(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processCancelSm(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processReplaceSm(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processReplaceSm(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    static final void processDeliverSmResp0(Command pduHeader, byte[] pdu,
-            ServerResponseHandler responseHandler) throws IOException {
+
+    static final void processDeliverSmResp0(Command pduHeader, byte[] pdu, ServerResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler.removeSentItem(pduHeader.getSequenceNumber());
         if (pendingResp != null) {
-            DeliverSmResp resp = pduDecomposer.deliverSmResp(pdu);
+            DeliverSmResp resp = AbstractGenericSMPPSessionBound.pduDecomposer.deliverSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.warn("No request with sequence number "
-                    + pduHeader.getSequenceNumber() + " found");
+            SMPPServerSessionBoundRX.logger.warn("No request with sequence number " + pduHeader.getSequenceNumber() + " found");
         }
     }
-    
+
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundRX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundRX.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -30,8 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is bound_tx state implementation of {@link SMPPSessionState}.
- * Response to receiver related transaction.
+ * This class is bound_tx state implementation of {@link SMPPSessionState}. Response to receiver related transaction.
  * 
  * @author uudashr
  * @version 1.0
@@ -41,82 +36,76 @@ import org.slf4j.LoggerFactory;
 class SMPPSessionBoundRX extends SMPPSessionBound implements SMPPSessionState {
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionBoundRX.class);
     private static final PDUDecomposer pduDecomposer = new DefaultDecomposer();
-    
+
+    @Override
     public SessionState getSessionState() {
         return SessionState.BOUND_RX;
     }
-    
-    public void processDeliverSm(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        processDeliverSm0(pduHeader, pdu, responseHandler);
+
+    @Override
+    public void processDeliverSm(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        SMPPSessionBoundRX.processDeliverSm0(pduHeader, pdu, responseHandler);
     }
 
-    public void processSubmitSmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+    @Override
+    public void processDeliverSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendDeliverSmResp(0, pduHeader.getSequenceNumber());
     }
-    
-    public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processSubmitSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processQuerySmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processSubmitMultiResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processCancelSmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processQuerySmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processReplaceSmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processCancelSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    public void processAlertNotification(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) {
-        processAlertNotification0(pduHeader, pdu, responseHandler);
+
+    @Override
+    public void processReplaceSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
-    static void processAlertNotification0(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) {
+
+    @Override
+    public void processAlertNotification(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) {
+        SMPPSessionBoundRX.processAlertNotification0(pduHeader, pdu, responseHandler);
+    }
+
+    static void processAlertNotification0(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) {
         try {
-            AlertNotification alertNotification = pduDecomposer.alertNotification(pdu);
+            AlertNotification alertNotification = SMPPSessionBoundRX.pduDecomposer.alertNotification(pdu);
             responseHandler.processAlertNotification(alertNotification);
         } catch (PDUStringException e) {
-            logger.error("Failed decomposing alert_notification", e);
-            // there is no response for alert notification 
+            SMPPSessionBoundRX.logger.error("Failed decomposing alert_notification", e);
+            // there is no response for alert notification
         }
     }
-    
-    static void processDeliverSm0(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
+
+    static void processDeliverSm0(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
         try {
-            DeliverSm deliverSm = pduDecomposer.deliverSm(pdu);
-            responseHandler.processDeliverSm(deliverSm);
-            responseHandler.sendDeliverSmResp(0, pduHeader.getSequenceNumber());
+            DeliverSm deliverSm = SMPPSessionBoundRX.pduDecomposer.deliverSm(pdu);
+            if (responseHandler.processDeliverSm(deliverSm)) {
+                responseHandler.sendDeliverSmResp(0, pduHeader.getSequenceNumber());
+            }
         } catch (PDUStringException e) {
-            logger.error("Failed decomposing deliver_sm", e);
-            responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader
-                    .getSequenceNumber());
+            SMPPSessionBoundRX.logger.error("Failed decomposing deliver_sm", e);
+            responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader.getSequenceNumber());
+
         } catch (ProcessRequestException e) {
-            logger.error("Failed processing deliver_sm", e);
+            SMPPSessionBoundRX.logger.error("Failed processing deliver_sm", e);
             responseHandler.sendDeliverSmResp(e.getErrorCode(), pduHeader.getSequenceNumber());
         }
     }
-    
-    
+
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundTX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundTX.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -31,9 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is unbound state implementation of {@link SMPPSessionState}. This
- * class give specific response to a transmit related transaction, otherwise
- * it always give negative response.
+ * This class is unbound state implementation of {@link SMPPSessionState}. This class give specific response to a
+ * transmit related transaction, otherwise it always give negative response.
  * 
  * @author uudashr
  * @version 1.0
@@ -42,108 +37,97 @@ import org.slf4j.LoggerFactory;
  */
 class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionBoundTX.class);
-    
+
+    @Override
     public SessionState getSessionState() {
         return SessionState.BOUND_TX;
     }
-    
-    public void processSubmitSmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
 
-        PendingResponse<Command> pendingResp = responseHandler
-                .removeSentItem(pduHeader.getSequenceNumber());
+    @Override
+    public void processSubmitSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        PendingResponse<Command> pendingResp = responseHandler.removeSentItem(pduHeader.getSequenceNumber());
         if (pendingResp != null) {
             try {
-                SubmitSmResp resp = pduDecomposer.submitSmResp(pdu);
+                SubmitSmResp resp = AbstractGenericSMPPSessionBound.pduDecomposer.submitSmResp(pdu);
                 pendingResp.done(resp);
             } catch (PDUStringException e) {
-                logger.error("Failed decomposing submit_sm_resp", e);
-                responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader
-                        .getSequenceNumber());
+                SMPPSessionBoundTX.logger.error("Failed decomposing submit_sm_resp", e);
+                responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader.getSequenceNumber());
             }
         } else {
-            logger.warn("No request with sequence number "
-                    + pduHeader.getSequenceNumber() + " found");
-        }
-    }
-    
-    public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        PendingResponse<Command> pendingResp = responseHandler
-                .removeSentItem(pduHeader.getSequenceNumber());
-        if (pendingResp != null) {
-            try {
-                SubmitMultiResp resp = pduDecomposer.submitMultiResp(pdu);
-                pendingResp.done(resp);
-            } catch (PDUStringException e) {
-                logger.error("Failed decomposing submit_multi_resp", e);
-                responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader
-                        .getSequenceNumber());
-            }
-        } else {
-            logger.warn("No request with sequence number "
-                    + pduHeader.getSequenceNumber() + " found");
+            SMPPSessionBoundTX.logger.warn("No request with sequence number " + pduHeader.getSequenceNumber() + " found");
         }
     }
 
-    public void processQuerySmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-
-        PendingResponse<Command> pendingResp = responseHandler
-                .removeSentItem(pduHeader.getSequenceNumber());
+    @Override
+    public void processSubmitMultiResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        PendingResponse<Command> pendingResp = responseHandler.removeSentItem(pduHeader.getSequenceNumber());
         if (pendingResp != null) {
             try {
-                QuerySmResp resp = pduDecomposer.querySmResp(pdu);
+                SubmitMultiResp resp = AbstractGenericSMPPSessionBound.pduDecomposer.submitMultiResp(pdu);
                 pendingResp.done(resp);
             } catch (PDUStringException e) {
-                logger.error("Failed decomposing submit_sm_resp", e);
-                responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader
-                        .getSequenceNumber());
+                SMPPSessionBoundTX.logger.error("Failed decomposing submit_multi_resp", e);
+                responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader.getSequenceNumber());
             }
         } else {
-            logger.error("No request find for sequence number "
-                    + pduHeader.getSequenceNumber());
-            responseHandler.sendGenerickNack(
-                    SMPPConstant.STAT_ESME_RINVDFTMSGID, pduHeader
-                            .getSequenceNumber());
+            SMPPSessionBoundTX.logger.warn("No request with sequence number " + pduHeader.getSequenceNumber() + " found");
         }
     }
-    
-    public void processCancelSmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        PendingResponse<Command> pendingResp = responseHandler
-                .removeSentItem(pduHeader.getSequenceNumber());
+
+    @Override
+    public void processQuerySmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+
+        PendingResponse<Command> pendingResp = responseHandler.removeSentItem(pduHeader.getSequenceNumber());
         if (pendingResp != null) {
-            CancelSmResp resp = pduDecomposer.cancelSmResp(pdu);
+            try {
+                QuerySmResp resp = AbstractGenericSMPPSessionBound.pduDecomposer.querySmResp(pdu);
+                pendingResp.done(resp);
+            } catch (PDUStringException e) {
+                SMPPSessionBoundTX.logger.error("Failed decomposing submit_sm_resp", e);
+                responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader.getSequenceNumber());
+            }
+        } else {
+            SMPPSessionBoundTX.logger.error("No request find for sequence number " + pduHeader.getSequenceNumber());
+            responseHandler.sendGenerickNack(SMPPConstant.STAT_ESME_RINVDFTMSGID, pduHeader.getSequenceNumber());
+        }
+    }
+
+    @Override
+    public void processCancelSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        PendingResponse<Command> pendingResp = responseHandler.removeSentItem(pduHeader.getSequenceNumber());
+        if (pendingResp != null) {
+            CancelSmResp resp = AbstractGenericSMPPSessionBound.pduDecomposer.cancelSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.error("No request find for sequence number "
-                    + pduHeader.getSequenceNumber());
+            SMPPSessionBoundTX.logger.error("No request find for sequence number " + pduHeader.getSequenceNumber());
         }
     }
-    
-    public void processReplaceSmResp(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        PendingResponse<Command> pendingResp = responseHandler
-                .removeSentItem(pduHeader.getSequenceNumber());
+
+    @Override
+    public void processReplaceSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        PendingResponse<Command> pendingResp = responseHandler.removeSentItem(pduHeader.getSequenceNumber());
         if (pendingResp != null) {
-            ReplaceSmResp resp = pduDecomposer.replaceSmResp(pdu);
+            ReplaceSmResp resp = AbstractGenericSMPPSessionBound.pduDecomposer.replaceSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.error("No request find for sequence number "
-                    + pduHeader.getSequenceNumber());
+            SMPPSessionBoundTX.logger.error("No request find for sequence number " + pduHeader.getSequenceNumber());
         }
     }
-    
-    public void processDeliverSm(Command pduHeader, byte[] pdu,
-            ResponseHandler responseHandler) throws IOException {
-        responseHandler.sendNegativeResponse(pduHeader.getCommandId(),
-                SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader
-                        .getSequenceNumber());
+
+    @Override
+    public void processDeliverSm(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
     }
-    
+
+    @Override
+    public void processDeliverSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException {
+        responseHandler.sendNegativeResponse(pduHeader.getCommandId(), SMPPConstant.STAT_ESME_RINVBNDSTS, pduHeader.getSequenceNumber());
+    }
+
+    @Override
     public void processAlertNotification(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) {
-        logger.error("Receiving alert_notification while on invalid bound state (transmitter)");
+        SMPPSessionBoundTX.logger.error("Receiving alert_notification while on invalid bound state (transmitter)");
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionClosed.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionClosed.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -24,9 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is closed state implementation of {@link SMPPSessionState}. This
- * session state on SMPP specification context, implemented on since version 5.0,
- * but we can also use this.
+ * This class is closed state implementation of {@link SMPPSessionState}. This session state on SMPP specification
+ * context, implemented on since version 5.0, but we can also use this.
  * 
  * @author uudashr
  * @version 1.0
@@ -35,88 +30,111 @@ import org.slf4j.LoggerFactory;
  */
 class SMPPSessionClosed implements SMPPSessionState {
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionClosed.class);
-    
+
+    @Override
     public SessionState getSessionState() {
         return SessionState.CLOSED;
     }
-    
+
+    @Override
     public void processBindResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processDeliverSm(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
+    public void processDeliverSmResp(Command pduHeader, byte[] pdu,
+            ResponseHandler responseHandler) throws IOException {
+        throw new IOException("Invalid process for closed session state");
+    }
+
+    @Override
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processQuerySmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processSubmitSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
 
+    @Override
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processCancelSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processReplaceSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for closed session state");
     }
-    
+
+    @Override
     public void processAlertNotification(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) {
-        logger.error("SYSTEM ERROR. Receiving alert_notification while on invalid closed state");
+        SMPPSessionClosed.logger.error("SYSTEM ERROR. Receiving alert_notification while on invalid closed state");
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionOpen.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionOpen.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -32,8 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is open state implementation of {@link SMPPSessionState}. When
- * the session state is open, we only give positive response to bind related intention.
+ * This class is open state implementation of {@link SMPPSessionState}. When the session state is open, we only give
+ * positive response to bind related intention.
  * 
  * @author uudashr
  * @version 1.0
@@ -43,27 +39,29 @@ import org.slf4j.LoggerFactory;
 class SMPPSessionOpen implements SMPPSessionState {
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionOpen.class);
     private static final PDUDecomposer pduDecomposer = new DefaultDecomposer();
-    
+
+    @Override
     public SessionState getSessionState() {
         return SessionState.OPEN;
     }
-    
+
+    @Override
     public void processBindResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
                 .removeSentItem(pduHeader.getSequenceNumber());
         if (pendingResp != null) {
             try {
-                logger.debug("Bind Response header ("
+                SMPPSessionOpen.logger.debug("Bind Response header ("
                         + pduHeader.getCommandLength() + ", "
                         + pduHeader.getCommandIdAsHex() + ", "
                         + IntUtil.toHexString(pduHeader.getCommandStatus())
                         + ", " + pduHeader.getSequenceNumber() + ")");
-                BindResp resp = pduDecomposer.bindResp(pdu);
+                BindResp resp = SMPPSessionOpen.pduDecomposer.bindResp(pdu);
                 pendingResp.done(resp);
             } catch (PDUStringException e) {
                 String message = "Failed decomposing submit_sm_resp";
-                logger.error(message, e);
+                SMPPSessionOpen.logger.error(message, e);
                 responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader
                         .getSequenceNumber());
                 pendingResp
@@ -71,7 +69,7 @@ class SMPPSessionOpen implements SMPPSessionState {
                                 message, e));
             }
         } else {
-            logger.error("No request with sequence number "
+            SMPPSessionOpen.logger.error("No request with sequence number "
                     + pduHeader.getSequenceNumber() + " found");
             responseHandler.sendGenerickNack(
                     SMPPConstant.STAT_ESME_RINVDFTMSGID, pduHeader
@@ -79,6 +77,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processDeliverSm(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -89,6 +88,18 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
+    public void processDeliverSmResp(Command pduHeader, byte[] pdu,
+            ResponseHandler responseHandler) throws IOException {
+        PendingResponse<Command> pendingResp = responseHandler
+                .removeSentItem(1);
+        if (pendingResp != null) {
+            pendingResp.doneWithInvalidResponse(new InvalidResponseException(
+                    "Receive unexpected deliver_sm_resp"));
+        }
+    }
+
+    @Override
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -99,6 +110,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -109,6 +121,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) {
         PendingResponse<Command> pendingResp = responseHandler
@@ -119,6 +132,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processSubmitSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -128,7 +142,8 @@ class SMPPSessionOpen implements SMPPSessionState {
                     "Receive unexpected submit_sm_resp"));
         }
     }
-    
+
+    @Override
     public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -139,6 +154,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -149,6 +165,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -159,6 +176,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -169,6 +187,7 @@ class SMPPSessionOpen implements SMPPSessionState {
         }
     }
 
+    @Override
     public void processQuerySmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -178,7 +197,8 @@ class SMPPSessionOpen implements SMPPSessionState {
                     "Receive unexpected query_sm"));
         }
     }
-    
+
+    @Override
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -188,7 +208,8 @@ class SMPPSessionOpen implements SMPPSessionState {
                     "Receive unexpected data_sm"));
         }
     }
-    
+
+    @Override
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -198,7 +219,8 @@ class SMPPSessionOpen implements SMPPSessionState {
                     "Receive unexpected data_sm_resp"));
         }
     }
-    
+
+    @Override
     public void processCancelSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler
@@ -208,17 +230,19 @@ class SMPPSessionOpen implements SMPPSessionState {
                     "Receive unexpected cancel_sm_resp"));
         }
     }
-    
+
+    @Override
     public void processReplaceSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         PendingResponse<Command> pendingResp = responseHandler.removeSentItem(1);
-        
+
         if (pendingResp != null) {
             pendingResp.doneWithInvalidResponse(new InvalidResponseException(
                     "Receive unexpected replace_sm_resp"));
         }
     }
-    
+
+    @Override
     public void processAlertNotification(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) {
         PendingResponse<Command> pendingResp = responseHandler

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionState.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionState.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -20,9 +16,8 @@ import org.jsmpp.bean.Command;
 import org.jsmpp.session.ResponseHandler;
 
 /**
- * This class is provide interface to response to every incoming SMPP Commands.
- * How the the response behavior is depends to it's states, or the
- * implementation of this class.
+ * This class is provide interface to response to every incoming SMPP Commands. How the the response behavior is depends
+ * to it's states, or the implementation of this class.
  * 
  * @author uudashr
  * @version 1.0
@@ -36,48 +31,62 @@ public interface SMPPSessionState extends GenericSMPPSessionState {
     public static final SMPPSessionState UNBOUND = new SMPPSessionUnbound();
     public static final SMPPSessionState CLOSED = new SMPPSessionClosed();
 
-    
     /**
      * Process the bind response command.
      * 
-     * @param pduHeader is the PDU header.
-     * @param pdu is the complete PDU.
-     * @param responseHandler is the session handler.
-     * @throws IOException throw if there is an IO error occur.
+     * @param pduHeader
+     *            is the PDU header.
+     * @param pdu
+     *            is the complete PDU.
+     * @param responseHandler
+     *            is the session handler.
+     * @throws IOException
+     *             throw if there is an IO error occur.
      */
     void processBindResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
 
-
     /**
      * Process the submit short message response command.
      * 
-     * @param pduHeader is the PDU header.
-     * @param pdu is the complete PDU.
-     * @param responseHandler is the response handler.
-     * @throws IOException if there is an I/O error found.
+     * @param pduHeader
+     *            is the PDU header.
+     * @param pdu
+     *            is the complete PDU.
+     * @param responseHandler
+     *            is the response handler.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     void processSubmitSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
-    
+
     /**
      * Process a submit multiple message response.
      * 
-     * @param pduHeader is the PDU header.
-     * @param pdu is the complete PDU.
-     * @param responseHandler is the response handler.
-     * @throws IOException if there is an I/O error found.
+     * @param pduHeader
+     *            is the PDU header.
+     * @param pdu
+     *            is the complete PDU.
+     * @param responseHandler
+     *            is the response handler.
+     * @throws IOException
+     *             if there is an I/O error found.
      */
     void processSubmitMultiResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
-    
+
     /**
      * Process the query short message response command.
      * 
-     * @param pduHeader is the PDU header.
-     * @param pdu is the complete PDU.
-     * @param responseHandler is the session handler.
-     * @throws IOException throw if there is an IO error occur.
+     * @param pduHeader
+     *            is the PDU header.
+     * @param pdu
+     *            is the complete PDU.
+     * @param responseHandler
+     *            is the session handler.
+     * @throws IOException
+     *             throw if there is an IO error occur.
      */
     void processQuerySmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
@@ -85,20 +94,26 @@ public interface SMPPSessionState extends GenericSMPPSessionState {
     /**
      * Process the deliver short message request command.
      * 
-     * @param pduHeader is the PDU header.
-     * @param pdu is the complete PDU.
-     * @param responseHandler is the session handler.
-     * @throws IOException throw if there is an IO error occur.
+     * @param pduHeader
+     *            is the PDU header.
+     * @param pdu
+     *            is the complete PDU.
+     * @param responseHandler
+     *            is the session handler.
+     * @throws IOException
+     *             throw if there is an IO error occur.
      */
     void processDeliverSm(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
-    
+
+    void processDeliverSmResp(Command pduHeader, byte[] pdu, ResponseHandler responseHandler) throws IOException;
+
     void processCancelSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
-    
+
     void processReplaceSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException;
-    
+
     void processAlertNotification(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler);
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionUnbound.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionUnbound.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.session.state;
 
@@ -24,9 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is unbound state implementation of {@link SMPPSessionState}. All
- * this method is throw {@link IOException} since when the state is unbound we
- * should not give any positive response.
+ * This class is unbound state implementation of {@link SMPPSessionState}. All this method is throw {@link IOException}
+ * since when the state is unbound we should not give any positive response.
  * 
  * @author uudashr
  * @version 1.0
@@ -35,88 +30,111 @@ import org.slf4j.LoggerFactory;
  */
 class SMPPSessionUnbound implements SMPPSessionState {
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionUnbound.class);
-    
+
+    @Override
     public SessionState getSessionState() {
         return SessionState.UNBOUND;
     }
-    
+
+    @Override
     public void processBindResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processDeliverSm(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
+    public void processDeliverSmResp(Command pduHeader, byte[] pdu,
+            ResponseHandler responseHandler) throws IOException {
+        throw new IOException("Invalid process for unbound session state");
+    }
+
+    @Override
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processSubmitSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
 
+    @Override
     public void processQuerySmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processCancelSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processReplaceSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
         throw new IOException("Invalid process for unbound session state");
     }
-    
+
+    @Override
     public void processAlertNotification(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) {
-        logger.error("SYSTEM ERROR. Receiving alert_notification while on unbound state");
+        SMPPSessionUnbound.logger.error("SYSTEM ERROR. Receiving alert_notification while on unbound state");
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/util/PDUDecomposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/PDUDecomposer.java
@@ -167,7 +167,7 @@ public interface PDUDecomposer {
     QuerySm querySm(byte[] b) throws PDUStringException;
 
     /**
-     * Decompose the SMPP PDU query short message reponse command.
+     * Decompose the SMPP PDU query short message response command.
      * 
      * @param b is the PDU.
      * @return the query short message response command object.

--- a/jsmpp/src/test/java/org/jsmpp/util/DateFormatterTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/DateFormatterTest.java
@@ -1,16 +1,12 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.jsmpp.util;
 
@@ -20,49 +16,47 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import static org.testng.Assert.*;
-
+import org.testng.Assert;
 import org.testng.annotations.Test;
-
 
 /**
  * @author uudashr
- *
+ * 
  */
 public class DateFormatterTest {
-    
-    @Test(groups="checkintest")
+
+    @Test(groups = "checkintest")
     public void testStaticAbsoluteFormatter() {
         String formatted = AbsoluteTimeFormatter.format(07, 12, 26, 11, 37, 03, 8, 45, '+');
-        assertEquals(formatted, "071226113703845+");
+        Assert.assertEquals(formatted, "071226113703845+");
     }
-    
-    @Test(groups="checkintest")
+
+    @Test(groups = "checkintest")
     public void testStaticRelativeFormatter() {
         String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
-        assertEquals(formatted, "071226124610000R");
+        Assert.assertEquals(formatted, "071226124610000R");
     }
-    
-    @Test(groups="checkintest")
+
+    @Test(groups = "checkintest")
     public void formatNullDate() {
         TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
-        assertNull(timeFormatter.format((Date)null));
-        assertNull(timeFormatter.format((Calendar)null));
-        
+        Assert.assertNull(timeFormatter.format((Date) null));
+        Assert.assertNull(timeFormatter.format((Calendar) null));
+
         timeFormatter = new RelativeTimeFormatter();
-        assertNull(timeFormatter.format((Date)null));
-        assertNull(timeFormatter.format((Calendar)null));
+        Assert.assertNull(timeFormatter.format((Date) null));
+        Assert.assertNull(timeFormatter.format((Calendar) null));
     }
-    
-    @Test(groups="checkintest")
+
+    @Test(groups = "checkintest")
     public void validateAbsoluteDate() throws Exception {
         String formatted = AbsoluteTimeFormatter.format(07, 12, 26, 11, 37, 03, 8, 45, '+');
         StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
         StringValidator.validateString(formatted, StringParameter.VALIDITY_PERIOD);
         StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
     }
-    
-    @Test(groups="checkintest")
+
+    @Test(groups = "checkintest")
     public void validateRelativeDate() throws Exception {
         String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
         StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
@@ -70,7 +64,7 @@ public class DateFormatterTest {
         StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
     }
 
-    @Test(groups="checkintest")
+    @Test(groups = "checkintest")
     public void formatAbsoluteDate() {
         TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
 
@@ -78,20 +72,20 @@ public class DateFormatterTest {
         date.set(Calendar.YEAR, 2013);
         date.set(Calendar.MONTH, Calendar.JANUARY);
         date.set(Calendar.DAY_OF_MONTH, 1);
-        date.set(Calendar.HOUR, 1);
+        date.set(Calendar.HOUR_OF_DAY, 13);
         date.set(Calendar.MINUTE, 0);
         date.set(Calendar.SECOND, 0);
         date.set(Calendar.MILLISECOND, 0);
 
-        assertEquals(timeFormatter.format(date), "130101130000004+");
+        Assert.assertEquals(timeFormatter.format(date), "130101130000004+");
 
         date.set(Calendar.MONTH, Calendar.JULY);
 
         // because of daylight saving time, we have a different offset
-        assertEquals(timeFormatter.format(date), "130701130000008+");
+        Assert.assertEquals(timeFormatter.format(date), "130701130000008+");
     }
 
-    @Test(groups="checkintest")
+    @Test(groups = "checkintest")
     public void formatRelativeDate() {
         RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter(TimeZone.getTimeZone("America/Denver"));
 
@@ -100,23 +94,23 @@ public class DateFormatterTest {
         date.set(Calendar.YEAR, 2013);
         date.set(Calendar.MONTH, Calendar.JANUARY);
         date.set(Calendar.DAY_OF_MONTH, 1);
-        date.set(Calendar.HOUR, 1);
+        date.set(Calendar.HOUR_OF_DAY, 13);
         date.set(Calendar.MINUTE, 0);
         date.set(Calendar.SECOND, 0);
         date.set(Calendar.MILLISECOND, 0);
 
-        assertEquals(timeFormatter.format(date), "130101050000000R");
-        
+        Assert.assertEquals(timeFormatter.format(date), "130101050000000R");
+
         // at this date Denver has already daylight saving time but not Germany
         date.set(Calendar.MONTH, Calendar.MARCH);
         date.set(Calendar.DAY_OF_MONTH, 20);
-        
-        assertEquals(timeFormatter.format(date), "130320060000000R");
+
+        Assert.assertEquals(timeFormatter.format(date), "130320060000000R");
 
         // at this date Denver and Germany has daylight saving time
         date.set(Calendar.MONTH, Calendar.APRIL);
         date.set(Calendar.DAY_OF_MONTH, 1);
 
-        assertEquals(timeFormatter.format(date), "130401050000000R");
+        Assert.assertEquals(timeFormatter.format(date), "130401050000000R");
     }
 }


### PR DESCRIPTION
Modifying the interface MessageReceiverListener, adding a boolean return value to onAcceptDeliverSm the user can choose if JSMPP sends the deliver_sm_resp message once the method has finished or (using FALSE value) doesn't allow to JSMPP to send the message.

This modification is necessary for working with async systems (Vert.x for example). With async system you can not send a response to SMSC because most of the times the original message ( deliver_sm ) has not been processed.

This PR also fix a NullPointer exception that happens when JSMPP tryes to bind to a SMSC that doesn't replay any optional parameter
