### PR TITLE
Fixed deadlock in SMPPSession/AbstractSession close methods

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -200,25 +200,32 @@ public abstract class AbstractSession implements Session {
     }
     
     public void close() {
-        logger.info("AbstractSession.close() called");
-        SessionContext ctx = sessionContext();
-        if (!ctx.getSessionState().equals(SessionState.CLOSED)) {
-            ctx.close();
-            try {
-                connection().close();
-            } catch (IOException e) {
-            }
-        }
-        
+      logger.info("AbstractSession.close() called");
+      SessionContext ctx = sessionContext();
+      if (!ctx.getSessionState().equals(SessionState.CLOSED)) {
+        ctx.close();
         try {
-        	if(enquireLinkSender != null) {
-        		enquireLinkSender.join();
-        	}
-		} catch (InterruptedException e) {
-			logger.warn("interrupted while waiting for enquireLinkSender thread to exit");
-		}
+          connection().close();
+        } catch (IOException e) {
+        }
+      }
+
+      // Make sure the enquireLinkThread doesn't wait for itself
+      if (Thread.currentThread() != enquireLinkSender)
+      {
+        if (enquireLinkSender != null)
+        {
+          try {
+            enquireLinkSender.join();
+          } catch (InterruptedException e) {
+            logger.warn("interrupted while waiting for enquireLinkSender thread to exit");
+          }
+        }
+      }
+
+      logger.info("AbstractSession.close() done");
     }
-    
+
     /**
      * Validate the response, the command_status should be 0 otherwise will
      * throw {@link NegativeResponseException}.
@@ -262,11 +269,21 @@ public abstract class AbstractSession implements Session {
         pendingResponse.put(seqNum, pendingResp);
         try {
             task.executeTask(connection().getOutputStream(), seqNum);
-        } catch (IOException e) {
-            logger.error("Failed sending " + task.getCommandName() + " command", e);
+        }
+        catch (IOException e)
+        {
+          logger.error("Failed sending " + task.getCommandName() + " command", e);
+          
+          if(task.getCommandName().equals("enquire_link"))
+          {
+            logger.info("Tomas: Ignore failure of sending enquire_link, wait to see if connection is restored");
+          }
+          else
+          {
             pendingResponse.remove(seqNum);
             close();
             throw e;
+          }
         }
         
         try {
@@ -334,6 +351,8 @@ public abstract class AbstractSession implements Session {
     }
     
     public void unbindAndClose() {
+
+        logger.info("unbindAndClose() called");
         if (sessionContext().getSessionState().isBound()) {
             try {
                 unbind();
@@ -418,11 +437,14 @@ public abstract class AbstractSession implements Session {
                 try {
                     sendEnquireLink();
                 } catch (ResponseTimeoutException e) {
+                    logger.error("EnquireLinkSender.run() ResponseTimeoutException", e);
                     close();
                 } catch (InvalidResponseException e) {
+                    logger.error("EnquireLinkSender.run() InvalidResponseException", e);
                     // lets unbind gracefully
                     unbindAndClose();
                 } catch (IOException e) {
+                    logger.error("EnquireLinkSender.run() IOException", e);
                     close();
                 }
             }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -108,7 +108,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 	private MessageReceiverListener messageReceiverListener;
     private BoundSessionStateListener sessionStateListener = new BoundSessionStateListener();
     private SMPPSessionContext sessionContext = new SMPPSessionContext(this, sessionStateListener);
-	
+
 	/**
      * Default constructor of {@link SMPPSession}. The next action might be
      * connect and bind to a destination message center.
@@ -269,7 +269,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 	 * @param bindType is the bind type.
 	 * @param systemId is the system id.
 	 * @param password is the password.
-	 * @param systemTypeis the system type.
+	 * @param systemType is the system type.
 	 * @param interfaceVersion is the interface version.
 	 * @param addrTon is the address TON.
 	 * @param addrNpi is the address NPI.
@@ -454,22 +454,26 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 	@Override
 	public void close()
 	{
-		super.close();
+    super.close();
 
-		if(Thread.currentThread() != pduReaderWorker) {
-			try {
-				if(pduReaderWorker != null) {
-					pduReaderWorker.join();
-				}
-			} catch (InterruptedException e) {
-				logger.warn("Interrupted while waiting for pduReaderWorker thread to exit");
-			}
-		}
+// Moved all cleanup handling to superclass. This code may cause a deadlock because
+// PDUReaderWorker waits for EnquireLinkSender and visa versa
+//		if(Thread.currentThread() != pduReaderWorker) {
+//			try {
+//				if(pduReaderWorker != null) {
+//				    logger.trace("Try to join pduReaderWorker thread");
+//					pduReaderWorker.join();
+//					logger.trace("Joined");
+//				}
+//			} catch (InterruptedException e) {
+//				logger.warn("Interrupted while waiting for pduReaderWorker thread to exit");
+//			}
+//		}
 	}
 
 	@Override
 	protected void finalize() throws Throwable {
-		close();
+    close();
 	}
 	
 	private void fireAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
@@ -611,8 +615,8 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 	        try {
 	            Command pduHeader = null;
 	            byte[] pdu = null;
-	            
-                pduHeader = pduReader.readPDUHeader(in);
+
+				pduHeader = pduReader.readPDUHeader(in);
                 pdu = pduReader.readPDU(in, pduHeader);
 	            
                 /*
@@ -624,7 +628,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
                         sessionContext, responseHandler,
                         sessionContext, onIOExceptionTask);
 	            executorService.execute(task);
-	            
+
 	        } catch (InvalidCommandLengthException e) {
 	            logger.warn("Receive invalid command length", e);
 	            try {


### PR DESCRIPTION
I am using the jsmpp API to listen for incoming SMS messages on a socket connection.
In average this socket connection stopped every 24 hours. I could also make it stop by breaking the network connection between my server and the SMPP Gateway.

I turned out that it was a deadlock caused by the EnquireLinkSender thread waiting for the PDUReader thread and visa versa.

This pull request moves all cleanup code into the superclass (AbstractSession) and I have added a check for which thread is calling the close method.

After running with this patch the SMPP API is able to close properly without any deadlock.

I have added a watchdog in my code outside the SMPP API that reconnects the SMPP Session when this happens instead of making the jsmpp API handle this and restart itself.
